### PR TITLE
Publish CausalPFN training pipeline

### DIFF
--- a/.github/workflows/training-tests.yml
+++ b/.github/workflows/training-tests.yml
@@ -1,0 +1,24 @@
+name: Training tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Install CPU-only PyTorch
+        run: python -m pip install torch==2.5.1 --index-url https://download.pytorch.org/whl/cpu
+      - name: Install package and training test dependencies
+        run: python -m pip install -e ".[training,test]"
+      - name: Run offline training tests
+        run: python -m pytest tests

--- a/.github/workflows/training-tests.yml
+++ b/.github/workflows/training-tests.yml
@@ -5,12 +5,15 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.10"
           cache: pip

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ CausalPFN leverages the power of transformer architectures for amortized causal 
 - **⚡ GPU Accelerated**: Optimized for modern hardware with CUDA support
 - **📈 Benchmarked**: Competitive performance against state-of-the-art causal inference methods
 - **📊 Uplift-Modelling**: Supports treatment effect estimation for personalized decision-making in real-world applications
+- **🧠 Public Training Pipeline**: Includes the causal priors, loss, checkpointing, and distributed training
 
 ## Installation
 
@@ -153,6 +154,9 @@ Explore our notebook collection below. Before running the notebooks, make sure t
 ## Reproducibility
 
 To fully reproduce the [paper](https://arxiv.org/abs/2506.07918) results, see the [REPRODUCE](https://github.com/vdblm/CausalPFN/blob/main/REPRODUCE.md) file.
+
+The causal training stage is now public. See [TRAINING.md](TRAINING.md) for causal priors, Hydra configurations,
+checkpoint/resume flow, and distributed training commands.
 
 ## Citation
 

--- a/REPRODUCE.md
+++ b/REPRODUCE.md
@@ -2,6 +2,12 @@
 
 While the README was a simple showcase of the package, this is an in-depth step-by-step guide to reproduce the results in the paper. If your aim is to reproduce, you should follow this document.
 
+## Model training
+
+The causal training code used for CausalPFN is included in this repository. Follow [TRAINING.md](TRAINING.md) to install
+the training dependencies and run single- or multi-GPU training. We specifically warm-start the training with a predictive
+TabDPT checkpoint.
+
 ## Setting up the Environment
 
 The environment use for reproducibility is a little bit different, as we would need to run baselines in R and also CATENet which uses JaX. To do so, please run the following command to create a conda environment:

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -1,0 +1,101 @@
+# Training CausalPFN
+
+This repository now includes the recipe used for training the CausalPFN model. The default training warm-starts from the
+predictive TabDPT model with the commands below.
+
+## Installation
+
+Use Python 3.10 and install the training dependencies in a virtual environment:
+
+```bash
+python3.10 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[training]"
+```
+
+For a CUDA-enabled Conda environment, run:
+
+```bash
+conda env create -f env_training.yaml
+conda activate causalpfn-training
+```
+
+The default configuration automatically downloads `tabdpt_long_context.ckpt` from `vdblm/causalpfn` on Hugging Face at
+the pinned revision in `conf/model/tabdpt_long_context_pretrained.yaml`. Hugging Face caches the file locally. On an
+offline cluster, provide an existing file with `model.path=/path/to/tabdpt_long_context.ckpt`.
+
+The pinned upload commit is `83aad07da1cb077cfda4236878a1b07dc9f72a54`; the checkpoint SHA-256 is
+`5efc25bcb3a1b29770ca56873704d9d6bf0dcb5e393cd48b10f0552d2a425d41`.
+
+## Causal training
+
+The simplest run uses the synthetic backdoor prior, schedule-free AdamW, checkpointing, and lightweight held-out
+evaluation:
+
+```bash
+python train.py +experiment=simple_configuration
+```
+
+The default configuration uses 2,048 rows per generated table, a 20-layer transformer, batches of 32 tables, eight
+gradient-accumulation steps, and 128 optimizer updates per epoch.
+
+The retained synthetic experiments can be run with:
+
+```bash
+python train.py +experiment=synthetic_backdoor
+python train.py +experiment=ablation_polynomial_backdoor
+python train.py +experiment=ablation_sinusoidal_backdoor
+```
+
+To initialize the same architecture from scratch instead, explicitly add `model=tabdpt_long_context`.
+
+Hydra overrides can change any setting. For example, this performs a small diagnostic update without compilation:
+
+```bash
+python train.py +experiment=synthetic_backdoor \
+  trainer.max_epochs=1 trainer.num_model_updates=1 trainer.num_agg=1 \
+  trainer.batch_size=1 train_meta_dataset.n_samples=64 num_workers=0 compile=false
+```
+
+## Checkpoints and resuming
+
+Add checkpointing to an experiment with:
+
+```bash
+python train.py +experiment=synthetic_backdoor \
+  +callbacks@callbacks.checkpoint=checkpoint
+```
+
+`callbacks.checkpoint.checkpoint_root` is the destination root for newly written checkpoints. In contrast,
+`resume_training.checkpoint_path` names the exact existing `.pt` file to read when resuming model, optimizer, scheduler,
+and callback state:
+
+```bash
+python train.py +experiment=synthetic_backdoor \
+  resume_training=enabled \
+  resume_training.checkpoint_path=output/checkpoints/<run-name>/latest.pt
+```
+
+Weights & Biases is disabled by default. Enable it with `wandb=enabled` after configuring your account.
+
+## Distributed training
+
+Set the visible devices and use the included `torchrun` wrapper:
+
+```bash
+export CUDA_VISIBLE_DEVICES=0,1
+./train_parallel.sh +experiment=synthetic_backdoor
+```
+
+Use `--port=<port>` when several distributed runs share a host.
+
+## Tests
+
+Run the offline tests with:
+
+```bash
+pip install -e ".[training,test]"
+pytest tests
+```
+
+The test suite covers prior generation, the causal loss, in-memory evaluation, configuration composition, and checkpointing.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,12 +1,29 @@
-from .acic2016 import ACIC2016Dataset
-from .criteo import CriteoDataset
-from .hillstrom import HillstromDataset
-from .ihdp import IHDPDataset
-from .lenta import LentaDataset
-from .megafon import MegafonDataset
+from importlib import import_module
+
 from .polynomial import PolynomialDataset
-from .realcause import RealCauseLalondeCPSDataset, RealCauseLalondePSIDDataset
-from .retail_hero import X5Dataset
+from .sinusoidal import SinusoidalDataset
+
+_OPTIONAL_DATASETS = {
+    "ACIC2016Dataset": (".acic2016", "ACIC2016Dataset"),
+    "CriteoDataset": (".criteo", "CriteoDataset"),
+    "HillstromDataset": (".hillstrom", "HillstromDataset"),
+    "IHDPDataset": (".ihdp", "IHDPDataset"),
+    "LentaDataset": (".lenta", "LentaDataset"),
+    "MegafonDataset": (".megafon", "MegafonDataset"),
+    "RealCauseLalondeCPSDataset": (".realcause", "RealCauseLalondeCPSDataset"),
+    "RealCauseLalondePSIDDataset": (".realcause", "RealCauseLalondePSIDDataset"),
+    "X5Dataset": (".retail_hero", "X5Dataset"),
+}
+
+
+def __getattr__(name):
+    if name not in _OPTIONAL_DATASETS:
+        raise AttributeError(name)
+    module_name, class_name = _OPTIONAL_DATASETS[name]
+    value = getattr(import_module(module_name, __name__), class_name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     "ACIC2016Dataset",
@@ -19,4 +36,5 @@ __all__ = [
     "X5Dataset",  # marketting dataset
     "MegafonDataset",  # marketting dataset
     "PolynomialDataset",  # synthetic dataset
+    "SinusoidalDataset",  # synthetic dataset
 ]

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -1,9 +1,18 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 from sklearn.model_selection import StratifiedKFold, StratifiedShuffleSplit
+
+from causalpfn.synthetic import (
+    GaussianSampler,
+    GeneralizedLinearDataset,
+    LaplaceSampler,
+    SamplerType,
+    UniformIntegerSampler,
+    UniformSampler,
+)
 
 
 @dataclass

--- a/benchmarks/sinusoidal.py
+++ b/benchmarks/sinusoidal.py
@@ -1,44 +1,31 @@
-# A synthetic polynomial dataset for evaluating CATE estimation methods.
+# A synthetic sinusoidal dataset for evaluating CATE estimation methods.
 
 from typing import List, Tuple
 
 import numpy as np
 
-from .base import (
-    ATE_Dataset,
-    CATE_Dataset,
-    EvalDatasetCatalog,
-    GeneralizedLinearDataset,
-    SamplerType,
-    UniformIntegerSampler,
-)
+from .base import ATE_Dataset, CATE_Dataset, EvalDatasetCatalog, GeneralizedLinearDataset, SamplerType
 
 
-class PolynomialDataset(GeneralizedLinearDataset, EvalDatasetCatalog):
+class SinusoidalDataset(GeneralizedLinearDataset, EvalDatasetCatalog):
 
     def __init__(
         self,
-        n_tables: int = 50,
-        test_ratio: float = 0.2,
+        n_tables: int,
+        test_ratio: float,
+        frequency_sampler: List[SamplerType] | SamplerType,
         *args,
-        degree_sampler: List[SamplerType] | SamplerType = UniformIntegerSampler(2, 4),
         seed: int = 42,
-        standardize_covariates: bool = True,
         **kwargs,
     ) -> None:
-        GeneralizedLinearDataset.__init__(
-            self,
-            *args,
-            standardize_covariates=standardize_covariates,
-            **kwargs,
-        )
-        EvalDatasetCatalog.__init__(self, n_tables=n_tables, name="Polynomial")
+        GeneralizedLinearDataset.__init__(self, *args, **kwargs)
+        EvalDatasetCatalog.__init__(self, n_tables=n_tables, name="Sinusoidal")
 
-        # for the degree
-        if isinstance(degree_sampler, list):
-            self.degree_sampler = degree_sampler
+        # for the frequency
+        if isinstance(frequency_sampler, list):
+            self.frequency_sampler = frequency_sampler
         else:
-            self.degree_sampler = [degree_sampler]
+            self.frequency_sampler = [frequency_sampler]
 
         self.n_tables = n_tables
 
@@ -46,17 +33,17 @@ class PolynomialDataset(GeneralizedLinearDataset, EvalDatasetCatalog):
 
         self.seeds = [seed + i for i in range(self.n_tables)]
 
-    def sample_degree(self) -> int:
-        chosen_degree_sampler = self.degree_sampler[np.random.randint(len(self.degree_sampler))]
-        return chosen_degree_sampler((1,))[0]
+    def sample_frequency(self) -> int:
+        chosen_frequency_sampler = self.frequency_sampler[np.random.randint(len(self.frequency_sampler))]
+        return chosen_frequency_sampler((1,))[0]
 
     def covariates2features(self, covariates):
-        degree = self.sample_degree()
-        features = np.concatenate([covariates**i for i in range(1, degree + 1)], axis=1)
-        return features
+        return covariates
 
     def post_nonlinear(self, random_variable):
-        return random_variable
+        frequency = self.sample_frequency()
+        scale = np.std(random_variable)
+        return random_variable + np.sin(frequency * random_variable) * scale
 
     def __getitem__(self, index) -> Tuple[CATE_Dataset, ATE_Dataset]:
         if index >= self.n_tables:

--- a/conf/callbacks/checkpoint.yaml
+++ b/conf/callbacks/checkpoint.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - _self_
+
+_target_: causalpfn.training.callbacks.Checkpoint
+callback_name: checkpoint
+frequency: 1
+top_k: 2
+checkpoint_root: ${out_dir}/checkpoints/ # destination root for newly written checkpoints
+checkpoint_dir_name: null # automatically generate

--- a/conf/callbacks/eval_cate.yaml
+++ b/conf/callbacks/eval_cate.yaml
@@ -1,0 +1,22 @@
+defaults:
+  - /eval_dataset@eval_datasets.ihdp: ihdp
+  - /eval_dataset@eval_datasets.acic2016: acic2016
+  - /eval_dataset@eval_datasets.lalonde_cps: lalonde_cps
+  - /eval_dataset@eval_datasets.lalonde_psid: lalonde_psid
+  - /eval_dataset@eval_datasets.cubic: cubic
+  - /eval_dataset@eval_datasets.sinusoidal: sinusoidal
+  - /eval_dataset@eval_datasets.linear: linear
+  - _self_
+
+_target_: causalpfn.training.callbacks.EvalCATE
+callback_name: eval_cate
+frequency: 1
+cate_estimator_partial:
+  _target_: causalpfn.causal_estimator.CATEEstimator
+  _partial_: true
+  model_path: null
+  n_folds: 2 # the number of folds used for validating the model
+  device: ${default_device}
+  max_context_length: 4096 # NOTE: set to as large as your GPU can handle
+  max_query_length: 8192
+  calibrate: false

--- a/conf/callbacks/eval_cate_simple.yaml
+++ b/conf/callbacks/eval_cate_simple.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - /eval_dataset@eval_datasets.sinusoidal: sinusoidal
+  - /eval_dataset@eval_datasets.cubic: cubic
+  - _self_
+
+_target_: causalpfn.training.callbacks.EvalCATE
+callback_name: eval_cate
+frequency: 1
+cate_estimator_partial:
+  _target_: causalpfn.causal_estimator.CATEEstimator
+  _partial_: true
+  model_path: null
+  n_folds: 2 # the number of folds used for validating the model
+  device: ${default_device}
+  max_context_length: 4096 # NOTE: set to as large as your GPU can handle
+  max_query_length: 8192
+  calibrate: false

--- a/conf/eval_dataset/acic2016.yaml
+++ b/conf/eval_dataset/acic2016.yaml
@@ -1,0 +1,2 @@
+_target_: benchmarks.ACIC2016Dataset
+n_tables: 10

--- a/conf/eval_dataset/cubic.yaml
+++ b/conf/eval_dataset/cubic.yaml
@@ -1,0 +1,35 @@
+_target_: benchmarks.PolynomialDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 10
+  high: 20
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 1.0
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -1.0
+      high: 1.0
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -5.
+  high: 5.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -2.
+  high: 2.
+degree_sampler:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 3
+  high: 3
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 2048
+seed: 948
+test_ratio: 0.2
+n_tables: 10

--- a/conf/eval_dataset/ihdp.yaml
+++ b/conf/eval_dataset/ihdp.yaml
@@ -1,0 +1,2 @@
+_target_: benchmarks.IHDPDataset
+n_tables: 10

--- a/conf/eval_dataset/lalonde_cps.yaml
+++ b/conf/eval_dataset/lalonde_cps.yaml
@@ -1,0 +1,2 @@
+_target_: benchmarks.RealCauseLalondeCPSDataset
+n_tables: 10

--- a/conf/eval_dataset/lalonde_psid.yaml
+++ b/conf/eval_dataset/lalonde_psid.yaml
@@ -1,0 +1,2 @@
+_target_: benchmarks.RealCauseLalondePSIDDataset
+n_tables: 10

--- a/conf/eval_dataset/linear.yaml
+++ b/conf/eval_dataset/linear.yaml
@@ -1,0 +1,35 @@
+_target_: benchmarks.PolynomialDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 5
+  high: 10
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 0.1
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -0.1
+      high: 0.1
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -10.
+  high: 6.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -3.
+  high: 5.
+degree_sampler:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 1
+  high: 1
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 1024
+n_tables: 10
+seed: 847
+test_ratio: 0.2

--- a/conf/eval_dataset/sinusoidal.yaml
+++ b/conf/eval_dataset/sinusoidal.yaml
@@ -1,0 +1,35 @@
+_target_: benchmarks.SinusoidalDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 5
+  high: 10
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 0.1
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -0.1
+      high: 0.1
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -10.
+  high: 6.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -3.
+  high: 5.
+frequency_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: 2.5
+  high: 3.0
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 1024
+n_tables: 10
+seed: 3847
+test_ratio: 0.2

--- a/conf/experiment/ablation_polynomial_backdoor.yaml
+++ b/conf/experiment/ablation_polynomial_backdoor.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+defaults:
+  - /meta_dataset@train_meta_dataset: polynomial_backdoor
+  - /callbacks@callbacks.eval_cate: eval_cate_simple
+  - _self_
+  - /callbacks@callbacks.checkpoint: checkpoint # add the checkpointing callback
+
+train_meta_dataset:
+  device: cpu
+  n_samples: 2048
+
+trainer:
+  max_epochs: 300
+
+wandb:
+  tags:
+    experiment: ablation_polynomial_backdoor

--- a/conf/experiment/ablation_sinusoidal_backdoor.yaml
+++ b/conf/experiment/ablation_sinusoidal_backdoor.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - /meta_dataset@train_meta_dataset: sinusoidal_backdoor
+  - /callbacks@callbacks.eval_cate: eval_cate_simple
+  - _self_
+  - /callbacks@callbacks.checkpoint: checkpoint # add the checkpointing callback
+
+train_meta_dataset:
+  device: cpu
+  n_samples: 2048
+
+trainer:
+  max_epochs: 300
+
+# Add tags so that it is easier to filter the experiments in the W&B dashboard
+wandb:
+  tags:
+    experiment: ablation_sinusoidal_backdoor

--- a/conf/experiment/simple_configuration.yaml
+++ b/conf/experiment/simple_configuration.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+defaults:
+  - /meta_dataset@train_meta_dataset: synthetic_backdoor
+  - _self_
+  - /callbacks@callbacks.checkpoint: checkpoint # add the checkpointing callback
+  - /callbacks@callbacks.eval_cate: eval_cate_simple # add a simple evaluation of heterogeneous CATE
+
+train_meta_dataset:
+  device: cpu
+  n_samples: 2048

--- a/conf/experiment/synthetic_backdoor.yaml
+++ b/conf/experiment/synthetic_backdoor.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+defaults:
+  - /meta_dataset@train_meta_dataset: synthetic_backdoor
+  - _self_
+
+train_meta_dataset:
+  device: cpu
+  n_samples: 2048
+
+# Add tags so that it is easier to filter the experiments in the W&B dashboard
+wandb:
+  tags:
+    experiment: synthetic_backdoor

--- a/conf/hydra/default.yaml
+++ b/conf/hydra/default.yaml
@@ -1,0 +1,3 @@
+output_subdir: null
+run:
+  dir: .

--- a/conf/meta_dataset/linear_backdoor.yaml
+++ b/conf/meta_dataset/linear_backdoor.yaml
@@ -1,0 +1,34 @@
+_target_: causalpfn.training.priors.ablation.BackdoorSinusoidalMetaDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 5
+  high: 10
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 0.1
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -0.1
+      high: 0.1
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -10.
+  high: 6.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -3.
+  high: 5.
+frequency_sampler:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 0
+  high: 0
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 2048
+name: linear_backdoor
+post_padding_n_cols: 99

--- a/conf/meta_dataset/polynomial_backdoor.yaml
+++ b/conf/meta_dataset/polynomial_backdoor.yaml
@@ -1,0 +1,34 @@
+_target_: causalpfn.training.priors.ablation.BackdoorPolynomialMetaDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 10
+  high: 20
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 1.0
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -1.0
+      high: 1.0
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -5.
+  high: 5.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -2.
+  high: 2.
+degree_sampler:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 1
+  high: 4
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 2048
+name: polynomial_backdoor
+post_padding_n_cols: 99

--- a/conf/meta_dataset/sinusoidal_backdoor.yaml
+++ b/conf/meta_dataset/sinusoidal_backdoor.yaml
@@ -1,0 +1,34 @@
+_target_: causalpfn.training.priors.ablation.BackdoorSinusoidalMetaDataset
+x_dim_dist:
+  _target_: causalpfn.synthetic.UniformIntegerSampler
+  low: 5
+  high: 10
+noise_samplers:
+  _target_: omegaconf.OmegaConf.to_container # hack to turn ListConfig to a list
+  cfg:
+    - _target_: causalpfn.synthetic.GaussianSampler
+      loc: 0.0
+      scale: 0.1
+    - _target_: causalpfn.synthetic.UniformSampler
+      low: -0.1
+      high: 0.1
+    - _target_: causalpfn.synthetic.LaplaceSampler
+      loc: 0.0
+      scale: 0.1
+weight_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -10.
+  high: 6.
+covariate_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: -3.
+  high: 5.
+frequency_sampler:
+  _target_: causalpfn.synthetic.UniformSampler
+  low: 0.0
+  high: 2.0
+standardize_treatment: true
+standardize_outcome: true
+n_samples: 2048
+name: sinusoidal_backdoor
+post_padding_n_cols: 99

--- a/conf/meta_dataset/synthetic_backdoor.yaml
+++ b/conf/meta_dataset/synthetic_backdoor.yaml
@@ -1,0 +1,90 @@
+_target_: causalpfn.training.priors.BackdoorDGPMetaDataset
+X_y0_E_y0_y1_E_y1_generator:
+  _target_: causalpfn.training.priors.table_generators.SyntheticTableGenerator
+  device: ${..device}
+  n_layer_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 10
+    mean_min: 1
+    is_int: true
+    min_val: 2
+  n_hidden_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 50
+    mean_min: 5
+    is_int: true
+    min_val: 4
+  dense_prob_dist:
+    _target_: causalpfn.training.priors.UniformSampler
+    low: 1
+    high: 1
+  init_std_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 3.0
+    mean_min: 0.01
+    is_int: false
+    min_val: 0.0
+  noise_std_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 0.5
+    mean_min: 0.0001
+    is_int: false
+    min_val: 0.0
+  pre_sample_prob: 0.5
+  n_block_max_dist: null
+  categorical_columns_prob: 0.5
+  categorical_columns_ordered_prob: 0.5
+  independent_prob: 0.0
+T_given_X_generator:
+  _target_: causalpfn.training.priors.table_generators.SyntheticTableGenerator
+  device: ${..device}
+  n_layer_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 10
+    mean_min: 1
+    is_int: true
+    min_val: 2
+  noise_std_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 0.5
+    mean_min: 0.0001
+    is_int: false
+    min_val: 0.0
+  n_hidden_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 50
+    mean_min: 5
+    is_int: true
+    min_val: 4
+  dense_prob_dist:
+    _target_: causalpfn.training.priors.UniformSampler
+    low: 1
+    high: 1
+  init_std_dist:
+    _target_: causalpfn.training.priors.DeepTruncNormLogScaledSampler
+    mean_max: 3.0
+    mean_min: 0.01
+    is_int: false
+    min_val: 0.0
+  n_block_max_dist: null
+  categorical_columns_prob: 0.0
+  categorical_columns_ordered_prob: 0.0
+  independent_prob: 0.11
+  linear_probability: 0.1
+  linear_weights_std: 1.0
+max_n_covariates: 98
+layer_norm_covariates_prob: 0.5
+n_samples: 2048
+overlap_dist:
+  _target_: causalpfn.training.priors.UniformSampler
+  low: 0.5
+  high: 1
+treatment_standardize_p: 0.8
+degree_heterogeneity_dist:
+    _target_: causalpfn.training.priors.UniformSampler
+    low: 0.7
+    high: 1
+device: cpu
+ate_scale_dist: null
+post_padding_n_cols: 99
+name: synthetic_backdoor

--- a/conf/model/tabdpt_long_context.yaml
+++ b/conf/model/tabdpt_long_context.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+defaults:
+  - _self_
+
+model:
+  obj:
+    _target_: causalpfn.models.InContextModel
+    model:
+      _target_: causalpfn.models.TabDPTLongContextModel
+      dropout: 0.0
+      n_out: 10
+      nbins: 1024
+      nhead: 6
+      nhid: 768
+      ninp: 384
+      nlayers: 20
+      num_features: 100
+    model_config:
+      training:
+        dropout: ${...model.dropout}
+      model:
+        max_num_classes: ${...model.n_out}
+        nhead: ${...model.nhead}
+        emsize: ${...model.ninp}
+        nhid_factor: ${eval:'${...model.nhid} // ${...model.ninp}'}
+        nlayers: ${...model.nlayers}
+        max_num_features: ${...model.num_features}
+        nbins: ${...model.nbins}
+      env:
+        device: ${default_device}
+    sigma: ${sigma}
+trainer:
+  batch_size: 32
+  num_agg: 8
+compile: true

--- a/conf/model/tabdpt_long_context_pretrained.yaml
+++ b/conf/model/tabdpt_long_context_pretrained.yaml
@@ -1,0 +1,21 @@
+# @package _global_
+defaults:
+  - _self_
+
+model:
+  path: null # Optional local checkpoint override for offline training.
+  repo_id: vdblm/causalpfn
+  filename: tabdpt_long_context.ckpt
+  revision: 83aad07da1cb077cfda4236878a1b07dc9f72a54
+  # SHA-256: 5efc25bcb3a1b29770ca56873704d9d6bf0dcb5e393cd48b10f0552d2a425d41
+  obj:
+    _target_: causalpfn.models.load_pretrained_in_context_model
+    ckpt_path: ${..path}
+    repo_id: ${..repo_id}
+    filename: ${..filename}
+    revision: ${..revision}
+    sigma: ${sigma}
+trainer:
+  batch_size: 32
+  num_agg: 8
+compile: true

--- a/conf/optimizer/adam.yaml
+++ b/conf/optimizer/adam.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+defaults:
+  - _self_
+optimizer:
+  _target_: torch.optim.Adam
+  _partial_: true
+  lr: 0.0001
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+  T_max: ${eval:'${trainer.max_epochs} * ${trainer.num_model_updates}'}
+  _partial_: true

--- a/conf/optimizer/adamw.yaml
+++ b/conf/optimizer/adamw.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+defaults:
+  - _self_
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 0.0001
+  weight_decay: 0.05
+  betas: [0.9, 0.95]
+lr_scheduler:
+  _target_: torch.optim.lr_scheduler.CosineAnnealingLR
+  T_max: ${eval:'${trainer.max_epochs} * ${trainer.num_model_updates}'}
+  _partial_: true

--- a/conf/optimizer/schedulefree_adamw.yaml
+++ b/conf/optimizer/schedulefree_adamw.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+defaults:
+  - _self_
+optimizer:
+  _target_: schedulefree.AdamWScheduleFree
+  _partial_: true
+  lr: 0.0005
+  weight_decay: 0.05
+  warmup_steps: 1000
+  betas: [0.98, 0.999]
+lr_scheduler: null

--- a/conf/resume_training/disabled.yaml
+++ b/conf/resume_training/disabled.yaml
@@ -1,0 +1,1 @@
+enabled: false

--- a/conf/resume_training/enabled.yaml
+++ b/conf/resume_training/enabled.yaml
@@ -1,0 +1,2 @@
+enabled: true
+checkpoint_path: null # exact existing .pt file to read when resuming

--- a/conf/train.yaml
+++ b/conf/train.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - trainer: default
+  - hydra: default
+  - wandb: disabled # set to enabled for wandb logging
+  - resume_training: disabled
+  - optimizer: schedulefree_adamw
+  - _self_
+  - model: tabdpt_long_context_pretrained
+  - override hydra/hydra_logging: none # hack to fix the logging code
+  - override hydra/job_logging: none # hack to fix the logging code
+
+seed: 1234
+out_dir: output
+default_device: cuda:0
+
+# for better dataloading parallelism
+prefetch_factor: 4
+num_workers: 32
+
+sigma: 0.01 # Used in HL Gassuian loss

--- a/conf/trainer/default.yaml
+++ b/conf/trainer/default.yaml
@@ -1,0 +1,8 @@
+max_epochs: 2048
+num_model_updates: 128
+
+grad_clip: 1.0
+
+min_train_data_split: 0.333 # NOTE: 0.1 is a little unstable for us, so we are using 0.333
+max_train_data_split: 0.666
+overlap_threshold: 0.01

--- a/conf/wandb/disabled.yaml
+++ b/conf/wandb/disabled.yaml
@@ -1,0 +1,1 @@
+enabled: false

--- a/conf/wandb/enabled.yaml
+++ b/conf/wandb/enabled.yaml
@@ -1,0 +1,4 @@
+enabled: true
+project: CausalPFN
+run_name: null
+entity: null

--- a/env_reproduce.yaml
+++ b/env_reproduce.yaml
@@ -39,9 +39,7 @@ dependencies:
       - schedulefree==1.4.1
       - scikit-uplift==0.5.1
       - shap==0.43.0
-      - openml==0.15.1
       - scikit-learn==1.5.2
-      - gdown==5.2.0
       - pytest==8.3.5
       - pytest-cov==6.1.1
       - black==25.1.0

--- a/env_training.yaml
+++ b/env_training.yaml
@@ -1,0 +1,12 @@
+name: causalpfn-training
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pip
+  - pytorch=2.5.1
+  - pytorch-cuda=12.1
+  - pip:
+      - -e .[training]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
   "tqdm",
   "faiss-cpu>=1.9.0",
   "scikit-learn>=1.5.2",
-  "huggingface_hub"
+  "huggingface_hub",
+  "omegaconf>=2.3.0,<3"
 ]
 
 [tool.setuptools]
@@ -30,6 +31,15 @@ where = ["src"]
 
 
 [project.optional-dependencies]
+training = [
+  "hydra-core>=1.3.2,<2",
+  "schedulefree>=1.4.1,<2",
+  "wandb>=0.19,<1"
+]
+test = [
+  "pytest>=8.3,<9",
+  "pytest-cov>=6,<7"
+]
 dev = [
   "torch==2.3.1",
   "numpy==1.26.4",
@@ -52,6 +62,8 @@ dev = [
 ]
 
 [tool.isort]
+profile = "black"
+line_length = 120
 skip = [
     "venv/",
     ".pytest_cache/",

--- a/src/causalpfn/causal_estimator.py
+++ b/src/causalpfn/causal_estimator.py
@@ -62,6 +62,8 @@ class CausalEstimator(ABC):
         model_path (str): The path to the model checkpoint. Can be:
             - A local file path
             - A Hugging Face model path
+        icl_model (InContextModel, optional): An in-memory model, used by
+            training callbacks when ``model_path`` is ``None``.
         cache_dir (str, optional): Directory to cache downloaded models from Hugging Face.
             Defaults to ~/.cache/causalpfn.
         calibrate (bool): Whether to calibrate the model's temperature using n-fold cross-validation.
@@ -90,7 +92,7 @@ class CausalEstimator(ABC):
     def __init__(
         self,
         device: str,
-        model_path: str = "vdblm/causalpfn",
+        model_path: str | None = "vdblm/causalpfn",
         max_context_length: int = 4096,
         max_query_length: int = 4096,
         num_neighbours: int = 1024,
@@ -104,10 +106,11 @@ class CausalEstimator(ABC):
         ICE_n_samples: int = 1000,
         verbose: bool = False,
         cache_dir: str | None = None,
+        icl_model: InContextModel | None = None,
     ):
         self.model_path = model_path
         self.cache_dir = cache_dir if cache_dir is not None else os.path.join(Path.home(), ".cache", "causalpfn")
-        self.icl_model: InContextModel = None
+        self.icl_model = icl_model
 
         self.device = device
         self.max_context_length = max_context_length
@@ -144,18 +147,21 @@ class CausalEstimator(ABC):
         """
         Load the model from the specified path or download it from Hugging Face.
         """
-        model_path = self.model_path
+        if self.model_path is not None:
+            model_path = self.model_path
+            if is_hf_model_path(model_path):
+                model_path = download_from_hf_hub(model_path, self.cache_dir)
 
-        # Check if the model path is a Hugging Face model path
-        if is_hf_model_path(model_path):
-            model_path = download_from_hf_hub(model_path, self.cache_dir)
+            ckpt = torch.load(model_path, weights_only=False, map_location="cpu")
+            model_state = ckpt["model_state_dict"]
+            config = ckpt["model_config"]
+            self.icl_model = InContextModel.load(model_state=model_state, model_config=config)
+        elif self.icl_model is not None:
+            config = self.icl_model.model_config
+        else:
+            raise ValueError("Either model_path or icl_model must be provided.")
 
-        # Load the model from the local path
-        ckpt = torch.load(model_path, weights_only=False, map_location="cpu")
-        model_state = ckpt["model_state_dict"]
-        config = ckpt["model_config"]
-
-        self.icl_model = InContextModel.load(model_state=model_state, model_config=config).to(self.device)
+        self.icl_model.to(self.device)
 
         if config["model_type"] == "tabdpt":
             self.max_feature_size = config["model"]["max_num_features"] - 1

--- a/src/causalpfn/models/__init__.py
+++ b/src/causalpfn/models/__init__.py
@@ -1,3 +1,8 @@
 from .icl_model import InContextModel
-from .loading import load_pretrained_tabdpt_config, load_pretrained_tabdpt_model
+from .loading import (
+    load_pretrained_in_context_model,
+    load_pretrained_tabdpt_config,
+    load_pretrained_tabdpt_model,
+    resolve_pretrained_checkpoint,
+)
 from .model import TabDPTLongContextModel

--- a/src/causalpfn/models/icl_model.py
+++ b/src/causalpfn/models/icl_model.py
@@ -24,8 +24,6 @@ class InContextModel(nn.Module):
         self.model: nn.Module = model
         self.model_config = model_config
 
-        # self.prepare_input is to be called for each of the models to do any model-specific preprocessing
-        self.prepare_input = lambda x, y: (pad_x(x, model.num_features), y)
         self.nbins = model_config["model"]["nbins"]
         model_config["model_type"] = "tabdpt"
         model_config["sigma"] = sigma
@@ -42,6 +40,10 @@ class InContextModel(nn.Module):
         self.register_buffer("bin_edges", bin_edges)  # (nbins+1,)
         self.register_buffer("bin_width", bin_width)  # () – 0-D tensor
         self.register_buffer("bin_centers", bin_centers)  # (nbins,)
+
+    def prepare_input(self, x: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply model-specific input padding without capturing the model in a closure."""
+        return pad_x(x, self.model.num_features), y
 
     def _predict_mean(self, logits: torch.Tensor):
         probs = F.softmax(logits, dim=-1)
@@ -249,7 +251,7 @@ class InContextModel(nn.Module):
         y_context: torch.Tensor,
         X_query: torch.Tensor,
         t_query: torch.Tensor,
-        temperature: torch.Tensor, # shape: (num_temperatures, ),
+        temperature: torch.Tensor,  # shape: (num_temperatures, ),
         n_samples: int | None = None,
     ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
 
@@ -306,6 +308,22 @@ class InContextModel(nn.Module):
             t_query.unsqueeze(-1) == 1, samples * y1_scale + y1_shift, samples * y0_scale + y0_shift
         )
         return mean_shift_scaled, samples_shift_scaled
+
+    def get_param_groups(self):
+        """Return optimizer groups used by the published causal training run."""
+        if isinstance(self.model, TabDPTLongContextModel):
+            return [
+                {"params": self.model.transformer_encoder.parameters()},
+                {
+                    "params": [
+                        parameter
+                        for name, parameter in self.model.named_parameters()
+                        if not name.startswith("transformer_encoder")
+                    ],
+                    "weight_decay": 0.0,
+                },
+            ]
+        return self.model.parameters()
 
     @classmethod
     def load(cls, model_state: dict, model_config: dict) -> "InContextModel":

--- a/src/causalpfn/models/loading.py
+++ b/src/causalpfn/models/loading.py
@@ -1,4 +1,8 @@
+from pathlib import Path
+
 import torch
+from huggingface_hub import hf_hub_download
+from omegaconf import OmegaConf
 
 from .model import TabDPTLongContextModel
 
@@ -36,4 +40,42 @@ def load_pretrained_tabdpt_model(ckpt_path: str | None, ckpt: dict | None = None
 def load_pretrained_tabdpt_config(ckpt_path: str | None, ckpt: dict | None = None) -> dict:
     assert ckpt_path is not None or ckpt is not None, "Either ckpt_path or ckpt must be provided."
     checkpoint = torch.load(ckpt_path, weights_only=False, map_location="cpu") if ckpt is None else ckpt
-    return object_to_dict(checkpoint["cfg"])
+    config = checkpoint["cfg"]
+    if OmegaConf.is_config(config):
+        return OmegaConf.to_container(config, resolve=True)
+    return object_to_dict(config)
+
+
+def resolve_pretrained_checkpoint(
+    ckpt_path: str | Path | None,
+    repo_id: str | None,
+    filename: str | None,
+    revision: str | None,
+) -> str:
+    """Resolve a local warm start or download an immutable Hugging Face revision."""
+    if ckpt_path is not None:
+        path = Path(ckpt_path).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Predictive warm-start checkpoint not found: {path}")
+        return str(path)
+
+    if not repo_id or not filename or not revision:
+        raise ValueError("repo_id, filename, and a pinned revision are required when ckpt_path is not set.")
+    return hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+
+
+def load_pretrained_in_context_model(
+    ckpt_path: str | Path | None = None,
+    repo_id: str | None = None,
+    filename: str | None = None,
+    revision: str | None = None,
+    sigma: float = 0.5,
+):
+    """Load one predictive checkpoint and wrap it for causal in-context training."""
+    from .icl_model import InContextModel
+
+    resolved_path = resolve_pretrained_checkpoint(ckpt_path, repo_id, filename, revision)
+    checkpoint = torch.load(resolved_path, weights_only=False, map_location="cpu")
+    model_config = load_pretrained_tabdpt_config(ckpt_path=None, ckpt=checkpoint)
+    model = load_pretrained_tabdpt_model(ckpt_path=None, ckpt=checkpoint)
+    return InContextModel(model=model, model_config=model_config, sigma=sigma)

--- a/src/causalpfn/models/utils.py
+++ b/src/causalpfn/models/utils.py
@@ -5,5 +5,7 @@ def pad_x(X: torch.Tensor, num_features=100):
     if num_features is None:
         return X
     n_features = X.shape[-1]
-    zero_feature_padding = torch.zeros((*X.shape[:-1], num_features - n_features), device=X.device)
-    return torch.cat([X, zero_feature_padding], dim=-1)
+    if n_features > num_features:
+        raise ValueError(f"Cannot pad {n_features} features to the smaller size {num_features}.")
+    feature_padding = torch.zeros((*X.shape[:-1], num_features - n_features), dtype=X.dtype, device=X.device)
+    return torch.cat([X, feature_padding], dim=-1)

--- a/src/causalpfn/synthetic.py
+++ b/src/causalpfn/synthetic.py
@@ -1,0 +1,143 @@
+"""Lightweight synthetic data-generating processes shared by training and benchmarks."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+import numpy as np
+
+SamplerType = Callable[[tuple], np.ndarray]
+
+
+class LaplaceSampler:
+    def __init__(self, loc: float, scale: float):
+        self.loc = loc
+        self.scale = scale
+
+    def __call__(self, shape: tuple | None = None) -> np.ndarray | float:
+        return np.random.laplace(self.loc, self.scale, shape)
+
+
+class UniformSampler:
+    def __init__(self, low: float, high: float):
+        self.low = low
+        self.high = high
+
+    def __call__(self, shape: tuple | None = None) -> np.ndarray | float:
+        values = np.random.rand() if shape is None else np.random.rand(*shape)
+        return values * (self.high - self.low) + self.low
+
+
+class GaussianSampler:
+    def __init__(self, loc: float, scale: float):
+        self.loc = loc
+        self.scale = scale
+
+    def __call__(self, shape: tuple | None = None) -> np.ndarray | float:
+        return np.random.normal(self.loc, self.scale, shape)
+
+
+class UniformIntegerSampler:
+    def __init__(self, low: int, high: int):
+        self.low = low
+        self.high = high
+
+    def __call__(self, shape: tuple | None = None) -> np.ndarray | int:
+        return np.random.randint(self.low, self.high + 1, shape)
+
+
+class GeneralizedLinearDataset(ABC):
+    """Synthetic DGP with linear feature functions and optional nonlinearities."""
+
+    def __init__(
+        self,
+        n_samples: int = 2048,
+        x_dim_dist: Callable[[], int] = UniformIntegerSampler(5, 10),
+        noise_samplers: list[SamplerType] | SamplerType | None = None,
+        weight_sampler: list[SamplerType] | SamplerType = UniformSampler(-5.0, 5.0),
+        covariate_sampler: list[SamplerType] | SamplerType = UniformSampler(-2.0, 2.0),
+        standardize_treatment: bool = True,
+        standardize_outcome: bool = True,
+        standardize_covariates: bool = False,
+    ) -> None:
+        self.x_dim_dist = x_dim_dist
+        if noise_samplers is None:
+            noise_samplers = [
+                GaussianSampler(0.0, 1.0),
+                UniformSampler(-1.0, 1.0),
+                LaplaceSampler(0, 1.0),
+            ]
+        self.noise_samplers = noise_samplers if isinstance(noise_samplers, list) else [noise_samplers]
+        self.weight_sampler = weight_sampler if isinstance(weight_sampler, list) else [weight_sampler]
+        self.covariate_sampler = covariate_sampler if isinstance(covariate_sampler, list) else [covariate_sampler]
+        self.n_samples = n_samples
+        self.standardize_treatment = standardize_treatment
+        self.standardize_outcome = standardize_outcome
+        self.standardize_covariates = standardize_covariates
+
+    def sample_exogenous_noise(self, shape) -> np.ndarray:
+        sampler = self.noise_samplers[np.random.randint(len(self.noise_samplers))]
+        return sampler(shape)
+
+    def sample_weights(self, shape) -> np.ndarray:
+        sampler = self.weight_sampler[np.random.randint(len(self.weight_sampler))]
+        return sampler(shape)
+
+    def sample_covariates(self, shape) -> np.ndarray:
+        sampler = self.covariate_sampler[np.random.randint(len(self.covariate_sampler))]
+        return sampler(shape)
+
+    @abstractmethod
+    def covariates2features(self, covariates):
+        raise NotImplementedError
+
+    @abstractmethod
+    def post_nonlinear(self, random_variable):
+        raise NotImplementedError
+
+    def get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes(self, seed: int | None = None):
+        if seed is not None:
+            np.random.seed(seed)
+
+        n_dims = self.x_dim_dist()
+        covariates = self.sample_covariates((self.n_samples, n_dims))
+        covariate_features = self.covariates2features(covariates)
+        features_dims = covariate_features.shape[1]
+
+        w_T = self.sample_weights((features_dims,))
+        treatment_pre_logits = np.einsum("np,p->n", covariate_features, w_T)
+        treatment_logits = self.post_nonlinear(treatment_pre_logits) + self.sample_exogenous_noise((self.n_samples,))
+        if self.standardize_treatment:
+            treatment_logits = (treatment_logits - treatment_logits.mean()) / (treatment_logits.std() + 1e-20)
+        treatment_probs = 1 / (1 + np.exp(-treatment_logits))
+        treatments = np.random.binomial(1, treatment_probs, size=self.n_samples)
+
+        w_Y0 = self.sample_weights((features_dims,))
+        w_Y1 = self.sample_weights((features_dims,))
+        E_y0 = self.post_nonlinear(np.einsum("np,p->n", covariate_features, w_Y0))
+        E_y1 = self.post_nonlinear(np.einsum("np,p->n", covariate_features, w_Y1))
+        y0 = E_y0 + self.sample_exogenous_noise((self.n_samples,))
+        y1 = E_y1 + self.sample_exogenous_noise((self.n_samples,))
+
+        outcomes = np.where(treatments == 1, y1, y0)
+        if self.standardize_outcome:
+            outcomes_mean, outcomes_std = outcomes.mean(), outcomes.std() + 1e-20
+        else:
+            outcomes_mean, outcomes_std = 0, 1
+        outcomes = (outcomes - outcomes_mean) / outcomes_std
+        y0, y1 = (y0 - outcomes_mean) / outcomes_std, (y1 - outcomes_mean) / outcomes_std
+        E_y0, E_y1 = (E_y0 - outcomes_mean) / outcomes_std, (E_y1 - outcomes_mean) / outcomes_std
+
+        if self.standardize_covariates:
+            covariates = (covariates - covariates.mean(axis=0)) / (covariates.std(axis=0) + 1e-20)
+
+        return covariates, treatments, treatment_probs, y0, y1, E_y0, E_y1, outcomes
+
+
+__all__ = [
+    "GaussianSampler",
+    "GeneralizedLinearDataset",
+    "LaplaceSampler",
+    "SamplerType",
+    "UniformIntegerSampler",
+    "UniformSampler",
+]

--- a/src/causalpfn/training/__init__.py
+++ b/src/causalpfn/training/__init__.py
@@ -1,0 +1,9 @@
+"""Training utilities for the CausalPFN model.
+
+The training stack is optional; install CausalPFN with the ``training``
+extra before importing this package.
+"""
+
+from .trainer import calculate_loss, train
+
+__all__ = ["calculate_loss", "train"]

--- a/src/causalpfn/training/callbacks/__init__.py
+++ b/src/causalpfn/training/callbacks/__init__.py
@@ -1,0 +1,4 @@
+from .checkpoint import Checkpoint
+from .eval import EvalCATE
+
+__all__ = ["Checkpoint", "EvalCATE"]

--- a/src/causalpfn/training/callbacks/base.py
+++ b/src/causalpfn/training/callbacks/base.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+
+from torch.nn import Module
+from torch.optim import Optimizer
+
+
+class Callback(ABC):
+    """The base callback class that is used in training"""
+
+    def __init__(self, callback_name: str | None):
+        self.callback_name = callback_name or self.__class__.__name__
+
+    @abstractmethod
+    def __call__(
+        self,
+        callback_idx: int,
+        model: Module,
+        optimizer: Optimizer,
+        epoch: int,
+        train_loss: float,
+        device: str,
+        rank: int,
+        wandb_enabled: bool,
+        lr_scheduler=None,
+    ):
+        """
+        The method that is called during training after each epoch.
+
+        Args:
+            callback_idx (int): The index of the callback.
+            model (Module): The model being trained.
+            optimizer (Optimizer): The optimizer used for training.
+            epoch (int): The current epoch number.
+            train_loss (float): The training loss for the current epoch.
+            device (str): The device on which the model is trained.
+            rank (int): The rank of the process in distributed training.
+            wandb_enabled (bool): Whether Weights & Biases logging is enabled
+                                (guaranteed to be disabled for rank != 0)
+            lr_scheduler: Optional learning-rate scheduler whose state may be checkpointed.
+        """
+        pass

--- a/src/causalpfn/training/callbacks/checkpoint.py
+++ b/src/causalpfn/training/callbacks/checkpoint.py
@@ -1,0 +1,98 @@
+import os
+from datetime import datetime
+
+import torch
+import wandb
+from torch.optim import Optimizer
+
+from causalpfn.models import InContextModel
+
+from .base import Callback
+
+
+class Checkpoint(Callback):
+    """Store the top k models based on training loss"""
+
+    def __init__(
+        self,
+        checkpoint_root: str,
+        callback_name: str | None,
+        frequency: int = 1,
+        checkpoint_dir_name: str | None = None,
+        top_k: int = 2,
+    ):
+        super().__init__(callback_name=callback_name)
+        self.frequency = frequency
+        self.checkpoint_root = checkpoint_root
+
+        if wandb.run is not None:
+            self.default_name = f"wandb-{wandb.run.id}"
+        else:
+            self.default_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+        self.checkpoint_dir_name = checkpoint_dir_name or self.default_name
+        self.top_scores = [float("inf")] * top_k
+        self.top_epochs = [-1] * top_k
+        self.top_k = top_k
+
+    def load_state(self, checkpoint: dict) -> None:
+        """Restore callback bookkeeping, while accepting legacy checkpoints."""
+        self.default_name = checkpoint.get("run_name", self.default_name)
+        self.checkpoint_dir_name = checkpoint.get("checkpoint_dir_name", self.default_name)
+
+        scores = list(checkpoint.get("top_scores", []))[: self.top_k]
+        epochs = list(checkpoint.get("top_epochs", []))[: self.top_k]
+        self.top_scores = scores + [float("inf")] * (self.top_k - len(scores))
+        self.top_epochs = epochs + [-1] * (self.top_k - len(epochs))
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        callback_idx: int,
+        model: InContextModel,
+        optimizer: Optimizer,
+        epoch: int,
+        train_loss: float,
+        device: str,
+        rank: int,
+        wandb_enabled: bool,
+        lr_scheduler=None,
+    ):
+        if (epoch + 1) % self.frequency == 0:
+            checkpoint_dir = os.path.join(self.checkpoint_root, self.checkpoint_dir_name)
+            if rank == 0:
+                os.makedirs(checkpoint_dir, exist_ok=True)
+
+            save_top_checkpoint = False
+            if self.top_k > 0 and train_loss < self.top_scores[-1]:
+                removal_idx = self.top_epochs[-1]
+                if removal_idx != -1 and rank == 0:
+                    previous_checkpoint = os.path.join(checkpoint_dir, f"epoch_{removal_idx:04d}.pt")
+                    if os.path.exists(previous_checkpoint):
+                        os.remove(previous_checkpoint)
+                self.top_epochs[-1] = epoch
+                self.top_scores[-1] = train_loss
+                everything = list(zip(self.top_scores, self.top_epochs))
+                everything_sorted = sorted(everything, key=lambda x: x[0])
+                for i, (score, e) in enumerate(everything_sorted):
+                    self.top_scores[i] = score
+                    self.top_epochs[i] = e
+                save_top_checkpoint = True
+
+            training_state = {
+                "model_state_dict": getattr(model, "_orig_mod", model).state_dict(),
+                "model_config": model.model_config,
+                "optimizer_state_dict": optimizer.state_dict(),
+                "lr_scheduler_state_dict": lr_scheduler.state_dict() if lr_scheduler is not None else None,
+                "epoch": epoch,
+                "train_loss": train_loss,
+                "run_name": self.default_name,
+                "checkpoint_dir_name": self.checkpoint_dir_name,
+                "top_scores": self.top_scores,
+                "top_epochs": self.top_epochs,
+            }
+
+            if rank == 0:
+                if save_top_checkpoint:
+                    torch.save(training_state, os.path.join(checkpoint_dir, f"epoch_{epoch:04d}.pt"))
+                torch.save(training_state, os.path.join(checkpoint_dir, "latest.pt"))

--- a/src/causalpfn/training/callbacks/eval.py
+++ b/src/causalpfn/training/callbacks/eval.py
@@ -1,0 +1,99 @@
+"""
+A callback designed for evaluating the model performance on a test set.
+"""
+
+from typing import Any, Callable, Dict, Protocol
+
+import torch
+import wandb
+from torch.optim import Optimizer
+from tqdm import tqdm
+
+from causalpfn.causal_estimator import CATEEstimator
+from causalpfn.evaluation import calculate_pehe
+from causalpfn.models import InContextModel
+
+from .base import Callback
+
+
+class EvalCATE(Callback):
+    """
+    Evaluates the trained CATE model on a test set of causal datasets
+    """
+
+    def __init__(
+        self,
+        eval_datasets: Dict[str, "EvaluationDataset"],
+        cate_estimator_partial: Callable[[InContextModel], CATEEstimator],
+        callback_name: str | None,
+        frequency: int = 1,
+        estimator_fitting_kwargs: Dict | None = None,
+    ):
+        super().__init__(callback_name=callback_name)
+        self.frequency = frequency
+        self.eval_datasets = eval_datasets
+        self.cate_estimator_partial = cate_estimator_partial
+        self.num_evaluations = sum(len(eval_dataset) for eval_dataset in eval_datasets.values())
+        self.pbar = None
+        self.estimator_fitting_kwargs = estimator_fitting_kwargs or {}
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        callback_idx: int,
+        model: InContextModel,
+        optimizer: Optimizer,
+        epoch: int,
+        train_loss: float,
+        device: str,
+        rank: int,
+        wandb_enabled: bool,
+        lr_scheduler=None,
+    ):
+        if rank != 0:
+            return
+
+        if (epoch + 1) % self.frequency == 0:
+            if self.pbar is None:
+                self.pbar = tqdm(range(self.num_evaluations), desc="Evaluating CATE")
+            model.eval()
+            report = {}
+            for eval_dataset_name, eval_dataset in self.eval_datasets.items():
+                all_cate_pehe = []
+                for i in range(len(eval_dataset)):
+                    cate_estimator: CATEEstimator = self.cate_estimator_partial(icl_model=model, device=device)
+                    cate_data, ate_data = eval_dataset[i]
+                    X_train, t_train, y_train, X_test = (
+                        cate_data.X_train,
+                        cate_data.t_train,
+                        cate_data.y_train,
+                        cate_data.X_test,
+                    )
+                    cate_estimator.fit(
+                        X=X_train,
+                        t=t_train,
+                        y=y_train,
+                        **self.estimator_fitting_kwargs,
+                    )
+                    cate_estimate = cate_estimator.estimate_cate(
+                        X=X_test,
+                    )
+                    all_cate_pehe.append(calculate_pehe(cate_data.true_cate, cate_estimate))
+                    self.pbar.update(1)
+                report |= {f"{eval_dataset_name}/CATE PEHE": sum(all_cate_pehe) / len(all_cate_pehe)}
+            self.pbar.reset()
+
+            self.pbar.set_postfix(report)
+
+            if wandb_enabled:
+                wandb.log(
+                    dict([(f"callback{callback_idx}:{self.callback_name}/{k}", v) for k, v in report.items()]),
+                )
+
+            model.train()
+
+
+class EvaluationDataset(Protocol):
+    def __len__(self) -> int: ...
+
+    def __getitem__(self, index: int) -> tuple[Any, Any]: ...

--- a/src/causalpfn/training/distributed.py
+++ b/src/causalpfn/training/distributed.py
@@ -1,0 +1,71 @@
+import datetime
+import os
+import random
+import signal
+from typing import Tuple
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+
+def cleanup() -> None:
+    """Destroy the distributed process group when one is active."""
+    if dist.is_available() and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def signal_handler(*_) -> None:
+    """Clean up distributed state after an interrupt."""
+    print("Received Ctrl+C, exiting...")
+    cleanup()
+    raise KeyboardInterrupt
+
+
+def install_signal_handler() -> None:
+    signal.signal(signal.SIGINT, signal_handler)
+
+
+def init_dist(device: str) -> Tuple[bool, int, str, int]:
+    """Initialize torch.distributed from torchrun environment variables."""
+    if "LOCAL_RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        return False, 0, device, 1
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    if device.startswith("cuda"):
+        torch.cuda.set_device(local_rank)
+        resolved_device = f"cuda:{local_rank}"
+        backend = "nccl"
+    else:
+        resolved_device = "cpu"
+        backend = "gloo"
+
+    dist.init_process_group(
+        backend=backend,
+        init_method="env://",
+        timeout=datetime.timedelta(seconds=600),
+        world_size=world_size,
+        rank=rank,
+    )
+    barrier_kwargs = {"device_ids": [local_rank]} if backend == "nccl" else {}
+    dist.barrier(**barrier_kwargs)
+    return True, rank, resolved_device, world_size
+
+
+def seed_everything(base_seed: int, using_dist: bool, rank: int = 0) -> None:
+    """Seed Python, NumPy, and PyTorch, using a distinct seed per rank."""
+    if using_dist:
+        seed_source = random.Random(base_seed)
+        seeds = [seed_source.randint(0, 2**32 - 1) for _ in range(int(os.environ["WORLD_SIZE"]))]
+        seed = seeds[rank]
+    else:
+        seed = base_seed
+
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)

--- a/src/causalpfn/training/priors/__init__.py
+++ b/src/causalpfn/training/priors/__init__.py
@@ -1,0 +1,11 @@
+from .backdoor_prior import BackdoorDGPMetaDataset
+from .meta_dataset import MetaDataset
+from .utils import DeepTruncNormLogScaledSampler, PriorGenerationError, UniformSampler
+
+__all__ = [
+    "BackdoorDGPMetaDataset",
+    "DeepTruncNormLogScaledSampler",
+    "MetaDataset",
+    "PriorGenerationError",
+    "UniformSampler",
+]

--- a/src/causalpfn/training/priors/ablation/__init__.py
+++ b/src/causalpfn/training/priors/ablation/__init__.py
@@ -1,0 +1,4 @@
+from .backdoor_polynomial_prior import BackdoorPolynomialMetaDataset
+from .backdoor_sinusoidal_prior import BackdoorSinusoidalMetaDataset
+
+__all__ = ["BackdoorPolynomialMetaDataset", "BackdoorSinusoidalMetaDataset"]

--- a/src/causalpfn/training/priors/ablation/backdoor_polynomial_prior.py
+++ b/src/causalpfn/training/priors/ablation/backdoor_polynomial_prior.py
@@ -1,0 +1,61 @@
+from typing import List
+
+import numpy as np
+import torch
+
+from causalpfn.synthetic import GeneralizedLinearDataset, SamplerType, UniformIntegerSampler
+from causalpfn.training.priors.meta_dataset import MetaDataset
+
+
+class BackdoorPolynomialMetaDataset(GeneralizedLinearDataset, MetaDataset):
+
+    def __init__(
+        self,
+        post_padding_n_cols: int,
+        *args,
+        degree_sampler: List[SamplerType] | SamplerType = UniformIntegerSampler(2, 4),
+        name: str = "BackdoorPolynomialMetaDataset",
+        device: str = "cpu",
+        **kwargs,
+    ) -> None:
+        GeneralizedLinearDataset.__init__(self, *args, **kwargs)
+        MetaDataset.__init__(self, name=name, post_padding_n_cols=post_padding_n_cols)
+
+        # for the degree
+        if isinstance(degree_sampler, list):
+            self.degree_sampler = degree_sampler
+        else:
+            self.degree_sampler = [degree_sampler]
+
+        self.device = device
+
+    def sample_degree(self) -> int:
+        chosen_degree_sampler = self.degree_sampler[np.random.randint(len(self.degree_sampler))]
+        return chosen_degree_sampler((1,))[0]
+
+    def covariates2features(self, covariates):
+        degree = self.sample_degree()
+        features = np.concatenate([covariates**i for i in range(1, degree + 1)], axis=1)
+        return features
+
+    def post_nonlinear(self, random_variable):
+        return random_variable
+
+    def get_sample(self) -> dict:
+
+        covariates, treatments, propensities, y0, y1, E_y0, E_y1, outcomes = (
+            self.get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes()
+        )
+
+        numpy_dict = dict(
+            X=covariates,
+            t=treatments,
+            y=outcomes,
+            y0=y0,
+            y1=y1,
+            E_y0=E_y0,
+            E_y1=E_y1,
+            propensities=propensities,
+        )
+
+        return {k: torch.tensor(v, device=self.device).float() for k, v in numpy_dict.items()}

--- a/src/causalpfn/training/priors/ablation/backdoor_sinusoidal_prior.py
+++ b/src/causalpfn/training/priors/ablation/backdoor_sinusoidal_prior.py
@@ -1,0 +1,61 @@
+from typing import List
+
+import numpy as np
+import torch
+
+from causalpfn.synthetic import GeneralizedLinearDataset, SamplerType
+from causalpfn.training.priors.meta_dataset import MetaDataset
+
+
+class BackdoorSinusoidalMetaDataset(GeneralizedLinearDataset, MetaDataset):
+
+    def __init__(
+        self,
+        frequency_sampler: List[SamplerType] | SamplerType,  # This is a measure of model complexity
+        post_padding_n_cols: int,
+        *args,
+        name: str = "BackdoorSinusoidalMetaDataset",
+        device: str = "cpu",
+        **kwargs,
+    ) -> None:
+        GeneralizedLinearDataset.__init__(self, *args, **kwargs)
+        MetaDataset.__init__(self, name=name, post_padding_n_cols=post_padding_n_cols)
+
+        # for the frequency
+        if isinstance(frequency_sampler, list):
+            self.frequency_sampler = frequency_sampler
+        else:
+            self.frequency_sampler = [frequency_sampler]
+
+        self.device = device
+
+    def sample_frequency(self) -> int:
+        chosen_frequency_sampler = self.frequency_sampler[np.random.randint(len(self.frequency_sampler))]
+        return chosen_frequency_sampler((1,))[0]
+
+    def covariates2features(self, covariates):
+        return covariates
+
+    def post_nonlinear(self, random_variable):
+        frequency = self.sample_frequency()
+        return random_variable + np.sin(frequency * random_variable)
+
+    # override the sample method of MetaDataset
+    def get_sample(self) -> dict:
+
+        covariates, treatments, propensities, y0, y1, E_y0, E_y1, outcomes = (
+            self.get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes()
+        )
+
+        numpy_dict = dict(
+            X=covariates,
+            t=treatments,
+            y=outcomes,
+            y0=y0,
+            y1=y1,
+            E_y0=E_y0,
+            E_y1=E_y1,
+            propensities=propensities,
+        )
+
+        return {k: torch.tensor(v, device=self.device).float() for k, v in numpy_dict.items()}

--- a/src/causalpfn/training/priors/backdoor_prior.py
+++ b/src/causalpfn/training/priors/backdoor_prior.py
@@ -1,0 +1,187 @@
+from typing import Callable
+
+import torch
+
+from .meta_dataset import MetaDataset
+from .table_generators import TableGenerator
+from .utils import PriorGenerationError, degree_heterogeneity, scale_causal_effect
+
+
+def T_logits_to_propensities_and_T(treatment_logits: torch.Tensor, standardize_T: bool, overlap: float):
+    if standardize_T:
+        treatment_logits = (treatment_logits - treatment_logits.mean(dim=0)) / (treatment_logits.std(dim=0) + 1e-20)
+    p = torch.sigmoid(treatment_logits)
+    propensities = overlap * p + (p >= 0.5) * (1 - overlap)
+    treatments = (propensities > torch.rand_like(propensities)).float()
+    return propensities, treatments
+
+
+class BackdoorDGPMetaDataset(MetaDataset):
+    """
+    A data generating process for the backdoor setting. Here, we implement a method to return observational samples
+    X, T, Y, along with the potential outcomes Y0, Y1, and the expected potential outcomes E[Y0 | X], E[Y1 | X] as
+    the CEPO loss requires this to train the model.
+
+    To do so, we first sample a table from a joint distribution, select some of the columns as covariates at random,
+    and we also select 4 columns to construct our potential outcomes. Among these four columns, two of them act
+    as E[Y0 | X] and E[Y1 | X], while the other two act as the noise terms eta_0 and eta_1 that model the
+    aleatoric uncertainty in P(Y1 | X) and P(Y0 | X). We add the noise terms to the expected potential outcomes to
+    get the final potential outcomes.
+
+    Moreover, we sample the treatment assignment P(T | X) from a separate table generator to ensures the ignorability
+    assumption (backdoor criteria) holds. This function takes in a set of covariates and returns the treatment logits,
+    which are then passed through a sigmoid function to get the propensities. Here, we also control the overlap
+    post-hoc, similar to RealCause.
+
+    Note that we may make the treatment assignment randomized like an RCT with a specific distribution independent of
+    the covariates, or a treatment assignment based on a simple or complicated function of the covariates.
+
+    Args:
+        X_y0_E_y0_y1_E_y1_generator:
+            A table generator that samples from the covariates and potential outcome distribution.
+
+        T_given_X_generator: A table generator that samples logits for the treatment model P(T | X).
+
+        max_n_covariates: The maximum number of covariates to sample.
+
+        layer_norm_covariates_prob: The probability for whether to apply layer normalization to covariates.
+
+        n_samples: The number of samples to generate.
+
+        overlap_dist:
+            A distribution of the degree of overlap (between 0 and 1). If 1., leave treatment untouched;
+            if 0., push p(T = 1 | x) to 0. for all covariates x, where p(T = 1 | x) < 0.5 and
+            and push p(T = 1 | x) to 1. for all covariates x, where p(T = 1 | x) >= 0.5.
+            if 0 < overlap < 1, do a linear interpolation of the above
+
+        treatment_standardize_p:
+             A callable that returns whether to standardize the treatment logits before passing it into sigmoid.
+
+        degree_heterogeneity_dist:
+            A distribution for the degree of heterogeneity (between 0 and 1). When deg_hetero=1., y1 and y0 remain
+            unchanged. When deg_hetero=0, y1 - y0 is the same for all individuals.
+
+        device: The device to use for sampling (e.g., "cpu" or "cuda").
+
+        ate_scale_dist: A distribution for the scale of the causal effect (the value of ATE, optional).
+    """
+
+    def __init__(
+        self,
+        X_y0_E_y0_y1_E_y1_generator: TableGenerator,
+        T_given_X_generator: TableGenerator,
+        max_n_covariates: int,
+        layer_norm_covariates_prob: float,
+        n_samples: int,
+        overlap_dist: Callable[[], float],
+        treatment_standardize_p: float,
+        degree_heterogeneity_dist: Callable[[], float],
+        device: str,
+        ate_scale_dist: Callable[[], float] | None = None,
+        *args,
+        **kwargs,
+    ):
+        self.X_y0_E_y0_y1_E_y1_generator = X_y0_E_y0_y1_E_y1_generator
+        self.T_given_X_generator = T_given_X_generator
+
+        self.max_n_covariates = max_n_covariates
+        self.layer_norm_covariates_prob = layer_norm_covariates_prob
+        self.n_samples = n_samples
+        self.overlap_dist = overlap_dist
+        self.treatment_standardize_p = treatment_standardize_p
+        self.degree_heterogeneity_dist = degree_heterogeneity_dist
+        self.device = device
+
+        self.ate_scale_dist = ate_scale_dist
+
+        super().__init__(*args, **kwargs)
+
+    @torch.no_grad()
+    def get_sample(self) -> dict:
+
+        n_covariates = torch.randint(1, self.max_n_covariates + 1, (1,), device=self.device).item()
+        n_columns = n_covariates + 4  # 4 columns for potential outcomes
+
+        # sample the potential outcomes and covariates
+        X_y0_E_y0_y1_E_y1 = self.X_y0_E_y0_y1_E_y1_generator.sample_table(
+            n_samples=self.n_samples,
+            n_columns=n_columns,
+        )
+
+        # permute the columns to avoid any ordering effect
+        X_y0_E_y0_y1_E_y1 = X_y0_E_y0_y1_E_y1[:, torch.randperm(n_columns, device=self.device)]
+
+        covariates = X_y0_E_y0_y1_E_y1[:, :n_covariates]
+        potential_outcomes = X_y0_E_y0_y1_E_y1[:, n_covariates:]
+
+        # covariates normalize
+        covariates = (covariates - covariates.mean(dim=0)) / (covariates.std(dim=0) + 1e-20)
+        if torch.rand(1) < self.layer_norm_covariates_prob:
+            covariates = torch.nn.functional.layer_norm(covariates, covariates.shape[1:])
+
+        # expected potential outcomes and noises
+        E_y0, eta_0 = potential_outcomes[:, :1], potential_outcomes[:, 2:3]
+        E_y1, eta_1 = potential_outcomes[:, 1:2], potential_outcomes[:, 3:4]
+
+        # standardize the noise
+        eta_0, eta_1 = (
+            (eta_0 - eta_0.mean(dim=0)) / (eta_0.std(dim=0) + 1e-20),
+            (eta_1 - eta_1.mean(dim=0)) / (eta_1.std(dim=0) + 1e-20),
+        )
+
+        # scale noises
+        eta_0 *= torch.std(E_y0) * torch.rand(1, device=self.device)
+        eta_1 *= torch.std(E_y1) * torch.rand(1, device=self.device)
+
+        # center the noises
+        eta_0 = eta_0 * torch.randn_like(eta_0, device=self.device)
+        eta_1 = eta_1 * torch.randn_like(eta_1, device=self.device)
+
+        y0, y1 = E_y0 + eta_0, E_y1 + eta_1
+
+        # degree of heterogeneity
+        (y0_scale, y0_shift), (y1_scale, y1_shift) = degree_heterogeneity(
+            E_y0,
+            E_y1,
+            self.degree_heterogeneity_dist(),
+        )
+
+        # apply the deg_hetero
+        y0 = y0 * y0_scale + y0_shift
+        y1 = y1 * y1_scale + y1_shift
+
+        E_y0 = E_y0 * y0_scale + y0_shift
+        E_y1 = E_y1 * y1_scale + y1_shift
+
+        # size of causal effect
+        if self.ate_scale_dist is not None:
+            scale = scale_causal_effect(E_y0, E_y1, self.ate_scale_dist())
+            y0, y1 = y0 * scale, y1 * scale
+            E_y0, E_y1 = E_y0 * scale, E_y1 * scale
+
+        # sample a separate treatment model to ensure ignorability
+        treatment_logits = self.T_given_X_generator.sample_conditional_table(input=covariates, n_columns=1)
+
+        overlap = self.overlap_dist()
+
+        if overlap < 0 or overlap > 1:
+            raise PriorGenerationError("Overlap must be between 0 and 1")
+
+        treatment_standardize = torch.rand(1).item() < self.treatment_standardize_p
+        propensities, treatments = T_logits_to_propensities_and_T(
+            treatment_logits=treatment_logits,
+            standardize_T=treatment_standardize,
+            overlap=overlap,
+        )
+        outcomes = treatments * y1 + (1 - treatments) * y0
+
+        return dict(
+            X=covariates,
+            t=treatments.squeeze(),
+            y=outcomes.squeeze(),
+            y0=y0.squeeze(),
+            y1=y1.squeeze(),
+            E_y0=E_y0.squeeze(),
+            E_y1=E_y1.squeeze(),
+            propensities=propensities.squeeze(),
+        )

--- a/src/causalpfn/training/priors/meta_dataset.py
+++ b/src/causalpfn/training/priors/meta_dataset.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+
+from torch.utils.data import IterableDataset
+
+from causalpfn.models.utils import pad_x
+from causalpfn.training.priors.utils import PriorGenerationError
+
+
+class MetaDataset(IterableDataset, ABC):
+    """
+    Data used for training: for each call, it will return a set of samples from a random data-generating process.
+    It will output variables like covariates X, treatments T, CEPOs E[Y_t|X], potential outcomes Y_t,
+    observed outcomes Y, etc; anything needed for training the in-context model.
+    """
+
+    def __init__(self, name: str, post_padding_n_cols: int):
+        self.name = name
+
+        # padding the number of columns so that tables can be batched together for training
+        self.post_padding_n_cols = post_padding_n_cols
+
+        # the set of all of the warnings that have been raised
+        self.prior_generation_warnings = set()
+
+    @abstractmethod
+    def get_sample(self) -> dict:
+        raise NotImplementedError("Implement generating samples separately")
+
+    def __iter__(self):
+        while True:
+            try:
+                sample = self.get_sample()
+            except PriorGenerationError as error:
+                # This warning can be emitted once per worker.
+                message = str(error)
+                if message not in self.prior_generation_warnings:
+                    self.prior_generation_warnings.add(message)
+                    print(f"[Prior Warning] {message}")
+                continue
+
+            sample["X"] = pad_x(sample["X"], num_features=self.post_padding_n_cols)
+            yield sample

--- a/src/causalpfn/training/priors/table_generators/__init__.py
+++ b/src/causalpfn/training/priors/table_generators/__init__.py
@@ -1,0 +1,7 @@
+from .base import TableGenerator
+from .synthetic import SyntheticTableGenerator
+
+__all__ = [
+    "SyntheticTableGenerator",
+    "TableGenerator",
+]

--- a/src/causalpfn/training/priors/table_generators/base.py
+++ b/src/causalpfn/training/priors/table_generators/base.py
@@ -1,0 +1,71 @@
+from abc import ABC
+
+import torch
+
+
+class TableGenerator(ABC):
+    """
+    Abstract base class for table generation models.
+
+    This class defines the interface for generating synthetic or real-world tabular data, from either
+    joint distributions like P(X1, X2, ...) or conditional distributions like P(Y1, Y2, ... | X1, X2, ...).
+    Subclasses must implement the core sampling methods, i.e., `_sample_table` to generate tables unconditionally
+    and/or `_sample_conditional_table` to generate tables conditionally based on input data.
+
+    Attributes:
+        name (str): Human-readable name identifier for the generator.
+        device (str): Device string (e.g., 'cpu', 'cuda:0') where tensors will be placed.
+    """
+
+    def __init__(self, name: str, device: str, *args, **kwargs):
+        self.name = name
+        self.device = device
+
+    def __str__(self):
+        return self.name
+
+    def _sample_table(self, n_samples: int, n_columns: int, *args, **kwargs) -> torch.Tensor:
+        """
+        Internal method to sample a table unconditionally.
+
+        This method must be implemented by subclasses to define the core table generation logic.
+
+        Args:
+            n_samples (int): Number of rows to generate.
+            n_columns (int): Number of columns in the generated table.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            torch.Tensor: Generated table tensor of shape (n_samples, n_columns).
+
+        Raises:
+            NotImplementedError: If not implemented by subclass.
+        """
+        raise NotImplementedError("Subclasses should implement this method to sample a table.")
+
+    def _sample_conditional_table(self, input: torch.Tensor, n_columns: int, *args, **kwargs) -> torch.Tensor:
+        """
+        Internal method to sample a table conditionally based on input data.
+
+        This method must be implemented by subclasses to define conditional table generation logic.
+
+        Args:
+            input (torch.Tensor): Conditioning input tensor with shape (n_samples, n_input_features).
+            n_columns (int): Number of columns in the generated table.
+            *args: Variable length argument list.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            torch.Tensor: Generated table tensor conditioned on input of shape (n_samples, n_columns).
+
+        Raises:
+            NotImplementedError: If not implemented by subclass.
+        """
+        raise NotImplementedError("Subclasses should implement this method to sample a conditional table.")
+
+    def sample_table(self, n_samples: int, n_columns: int, *args, **kwargs) -> torch.Tensor:
+        return self._sample_table(n_samples=n_samples, n_columns=n_columns, *args, **kwargs).to(self.device)
+
+    def sample_conditional_table(self, input: torch.Tensor, n_columns: int, *args, **kwargs) -> torch.Tensor:
+        return self._sample_conditional_table(input=input, n_columns=n_columns, *args, **kwargs).to(self.device)

--- a/src/causalpfn/training/priors/table_generators/synthetic.py
+++ b/src/causalpfn/training/priors/table_generators/synthetic.py
@@ -1,0 +1,99 @@
+from typing import Callable
+
+import torch
+
+from causalpfn.training.priors.utils import num2cat
+
+from .base import TableGenerator
+from .utils import PFN_MLP
+
+
+class SyntheticTableGenerator(TableGenerator):
+
+    def __init__(
+        self,
+        device: str,
+        n_layer_dist: Callable[[], int],
+        n_hidden_dist: Callable[[], int],
+        dense_prob_dist: Callable[[], float],
+        init_std_dist: Callable[[], float],
+        noise_std_dist: Callable[[], float],
+        n_block_max_dist: Callable[[], int] | None,
+        categorical_columns_prob: float,
+        categorical_columns_ordered_prob: float,
+        pre_sample_prob: float = 0.0,
+        independent_prob: float = 0.0,  # if True, then P(Y|X) = P(Y) for conditional tables
+        linear_probability: float = 0.0,
+        linear_weights_std: float = 1.0,
+    ):
+        self.n_layer_dist = n_layer_dist
+        self.n_hidden_dist = n_hidden_dist
+        self.dense_prob_dist = dense_prob_dist
+        self.init_std_dist = init_std_dist
+        self.noise_std_dist = noise_std_dist
+        self.n_block_max_dist = n_block_max_dist
+        self.independent_prob = independent_prob
+        self.pre_sample_prob = pre_sample_prob
+        self.categorical_columns_prob = categorical_columns_prob
+        self.categorical_columns_ordered_prob = categorical_columns_ordered_prob
+        self.linear_probability = linear_probability
+        self.linear_weights_std = linear_weights_std
+
+        super().__init__(device=device, name="Synthetic PFN MLP")
+
+    def _add_categorical_covariates(self, table: torch.Tensor) -> torch.Tensor:
+        if torch.rand(1) < self.categorical_columns_prob:
+            for col in range(table.shape[-1]):
+                if torch.rand(1) < 0.5:
+                    max_categories = max(round(torch.distributions.Gamma(1, 0.1).sample().item()), 2)
+                    table[..., col] = num2cat(
+                        table[..., col],
+                        max_categories,
+                        ordered_p=self.categorical_columns_ordered_prob,
+                    )
+
+        return table
+
+    def _sample_table(self, n_samples: int, n_columns: int) -> torch.Tensor:
+        model = PFN_MLP(
+            input_dim=self.n_hidden_dist(),
+            n_columns=n_columns,
+            n_layers=self.n_layer_dist(),
+            mlp_hidden_dim=self.n_hidden_dist(),
+            dense_prob=self.dense_prob_dist(),
+            init_std=self.init_std_dist(),
+            noise_std=self.noise_std_dist(),
+            n_block_max=self.n_block_max_dist() if self.n_block_max_dist is not None else None,
+            device=self.device,
+            pre_sample=torch.rand(1) < self.pre_sample_prob,
+        )
+        table = model.forward(inp=None, n_samples=n_samples)
+        return self._add_categorical_covariates(table)
+
+    def _sample_nonlinear_conditional_table(self, input: torch.Tensor, n_columns: int) -> torch.Tensor:
+        model = PFN_MLP(
+            input_dim=input.shape[-1],
+            n_columns=n_columns,
+            n_layers=self.n_layer_dist(),
+            mlp_hidden_dim=self.n_hidden_dist(),
+            dense_prob=self.dense_prob_dist(),
+            init_std=self.init_std_dist(),
+            noise_std=self.noise_std_dist(),
+            n_block_max=self.n_block_max_dist() if self.n_block_max_dist is not None else None,
+            device=self.device,
+            pre_sample=torch.rand(1) < self.pre_sample_prob,
+        )
+        table = model.forward(inp=input)
+        return self._add_categorical_covariates(table)
+
+    def _sample_linear_conditional_table(self, input: torch.Tensor, n_columns: int) -> torch.Tensor:
+        weights = torch.randn(input.shape[-1], n_columns, device=self.device) * self.linear_weights_std
+        bias = torch.randn(n_columns, device=self.device) * self.linear_weights_std
+        return torch.matmul(input, weights) + bias
+
+    def _sample_conditional_table(self, input: torch.Tensor, n_columns: int) -> torch.Tensor:
+        if torch.rand(1) < self.independent_prob:
+            return self._sample_table(n_samples=input.shape[0], n_columns=n_columns)
+        if torch.rand(1) < self.linear_probability:
+            return self._sample_linear_conditional_table(input, n_columns)
+        return self._sample_nonlinear_conditional_table(input, n_columns)

--- a/src/causalpfn/training/priors/table_generators/utils.py
+++ b/src/causalpfn/training/priors/table_generators/utils.py
@@ -1,0 +1,226 @@
+import math
+
+import torch
+from torch import nn
+from torch.distributions import Bernoulli as TorchBernoulli
+
+from causalpfn.training.priors.utils import PriorGenerationError
+
+
+class StepActivation(nn.Module):
+    def forward(self, input):
+        return torch.sign(input)
+
+
+class SineActivation(nn.Module):
+    def forward(self, input):
+        return torch.sin(input)
+
+
+class CosineActivation(nn.Module):
+    def forward(self, input):
+        return torch.cos(input)
+
+
+DEFAULT_ACT_FUNCS = [
+    CosineActivation,
+    SineActivation,
+    StepActivation,
+    nn.ELU,
+    nn.GELU,
+    nn.Hardsigmoid,
+    nn.Identity,
+    nn.LeakyReLU,
+    nn.LogSigmoid,
+    nn.Sigmoid,
+    nn.SiLU,
+    nn.Softplus,
+    nn.Tanh,
+]
+
+
+class GaussianNoise(nn.Module):
+    def __init__(self, std):
+        super().__init__()
+        self.std = std
+
+    def forward(self, x):
+        return x + torch.randn_like(x) * self.std
+
+
+class MaskedLinear(torch.nn.Linear):
+    def __init__(
+        self, in_features: int, out_features: int, mask: torch.Tensor, bias: bool = False, device: str = "cpu"
+    ):
+        """
+        Linear layer with an applied mask over the weights.
+
+        Parameters:
+            in_features: Number of input features.
+            out_features: Number of output features.
+            mask: Mask to apply over weights. Zero values in the mask will zero out the corresponding weights.
+            bias: If set to False, the layer will not learn an additive bias.
+        """
+        super().__init__(in_features=in_features, out_features=out_features, bias=bias, device=device)
+        if mask.size() != (in_features, out_features):
+            raise PriorGenerationError(
+                f"Mask size {mask.size()} does not match weight size {(in_features, out_features)}"
+            )
+        self.register_buffer("mask", mask.to(torch.bool))
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Forward pass of the MaskedLinear layer."""
+        return torch.nn.functional.linear(input, self.weight * self.mask.T, self.bias)
+
+
+class MaskedBlockLinear(MaskedLinear):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        mask: torch.Tensor,
+        bias: bool = False,
+        init_std: float = 1.0,
+        n_block_max: int | None = None,
+        device: str = "cpu",
+    ):
+        """
+        Block linear layer with an applied mask over the weights.
+
+        Parameters:
+            in_features: Number of input features.
+            out_features: Number of output features.
+            mask: Mask to apply over weights.
+            bias: If set to False, the layer will not learn an additive bias.
+            init_std: Standard deviation for the initialization.
+            n_block_max: Maximum number of blocks to use.
+        """
+        self.init_std = init_std
+        self.n_block_max = n_block_max
+        super().__init__(in_features=in_features, out_features=out_features, mask=mask, bias=bias, device=device)
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        # Blockwise dropout
+        torch.nn.init.zeros_(self.weight)
+        if self.n_block_max is None:
+            n_block_max = math.ceil(math.sqrt(min(self.weight.shape[0], self.weight.shape[1])))
+        else:
+            n_block_max = self.n_block_max
+
+        n_blocks = torch.randint(1, n_block_max + 1, ()).item()
+        n_blocks = min(n_blocks, self.weight.shape[0], self.weight.shape[1])
+        w, h = self.weight.shape[0] // n_blocks, self.weight.shape[1] // n_blocks
+        keep_prob = (
+            n_blocks * w * h
+        ) / self.weight.numel()  # Keeps the same standard deviation for the sume of the weights
+        for block in range(0, n_blocks):
+            torch.nn.init.normal_(
+                self.weight[
+                    w * block : w * (block + 1),
+                    h * block : h * (block + 1),
+                ],
+                std=self.init_std / keep_prob**0.5,
+            )
+
+
+class PFN_MLP(torch.nn.Module):
+
+    def __init__(
+        self,
+        input_dim: int,
+        n_columns: int,
+        n_layers: int,
+        mlp_hidden_dim: int,
+        dense_prob: float,
+        init_std: float,
+        noise_std: float,
+        n_block_max: int | None,
+        device: str,
+        pre_sample: bool,
+        name: str = "PFN MLP",
+    ):
+        super().__init__()
+
+        if n_layers <= 1:
+            raise PriorGenerationError(f"n_layers must be greater than 1, got {n_layers}")
+
+        if input_dim <= 0:
+            raise PriorGenerationError(f"input_dim must be greater than 0, got {input_dim}")
+
+        self.n_columns = n_columns
+
+        mlp_hidden_dim = max(mlp_hidden_dim, 2 * n_columns)
+
+        self.input_dim = input_dim
+        self.device = device
+        self.name = name
+        self.pre_sample = pre_sample
+
+        def rand_layer(out_dim):
+            mask = TorchBernoulli(torch.ones((mlp_hidden_dim, out_dim)) * dense_prob).sample().to(device)
+            modules = [
+                DEFAULT_ACT_FUNCS[torch.randint(0, len(DEFAULT_ACT_FUNCS), (1,))[0]](),
+                MaskedBlockLinear(
+                    mlp_hidden_dim,
+                    out_dim,
+                    mask=mask,
+                    bias=False,
+                    device=device,
+                    init_std=init_std,
+                    n_block_max=n_block_max,
+                ),
+                GaussianNoise(noise_std),
+            ]
+            return nn.Sequential(*modules)
+
+        mask = TorchBernoulli(torch.ones((input_dim, mlp_hidden_dim)) * dense_prob).sample().to(device)
+        self.layers = [
+            MaskedBlockLinear(
+                input_dim,
+                mlp_hidden_dim,
+                mask=mask,
+                bias=False,
+                device=device,
+                init_std=init_std,
+                n_block_max=n_block_max,
+            )
+        ]
+        self.layers += [rand_layer(mlp_hidden_dim) for _ in range(n_layers - 1)]
+        self.layers = nn.Sequential(*self.layers)
+
+    def forward(self, inp: torch.Tensor | None, n_samples: int | None = None) -> torch.Tensor:
+        if inp is not None and self.input_dim != inp.shape[-1]:
+            raise PriorGenerationError(f"Input shape {inp.shape} does not match {self.input_dim}")
+        if inp is None and n_samples is None:
+            raise PriorGenerationError("Either x or n_samples must be provided")
+
+        if inp is None:
+            if self.pre_sample:
+                x_mean = torch.normal(0, 1, size=(self.input_dim,), device=self.device)
+                x_std = (torch.normal(0, 1, size=(self.input_dim,), device=self.device) * x_mean).abs()
+                inp = torch.normal(
+                    mean=x_mean.unsqueeze(0).expand(n_samples, -1), std=x_std.unsqueeze(0).expand(n_samples, -1)
+                )
+            else:
+                inp = torch.normal(0.0, 1.0, size=(n_samples, self.input_dim), device=self.device)
+
+        inp = inp.to(self.device)
+        outputs = [inp]
+        for layer in self.layers:
+            outputs.append(layer(outputs[-1]))
+        outputs = outputs[2:]
+        outputs_flat: torch.Tensor = torch.cat(outputs, -1)
+
+        rand_indices = torch.randperm(outputs_flat.shape[-1], device=self.device)[: self.n_columns]
+        table = outputs_flat[:, rand_indices]
+
+        if torch.isnan(table).any():
+            raise PriorGenerationError(f"NaN in {self.name}")
+
+        # random covariates rotation
+        if table.shape[-1] > 0:
+            table_shift = torch.randint(0, table.shape[-1], (1,), device=self.device).item()
+            table = torch.cat((table[..., table_shift:], table[..., :table_shift]), dim=-1)
+
+        return table

--- a/src/causalpfn/training/priors/utils.py
+++ b/src/causalpfn/training/priors/utils.py
@@ -1,0 +1,140 @@
+import math
+from typing import Tuple
+
+import torch
+
+
+class PriorGenerationError(Exception):
+    pass
+
+
+class DeepTruncNormLogScaledSampler:
+    """Samples noise from a truncated normal distribution upon calling"""
+
+    def __init__(self, mean_min, mean_max, is_int, min_val):
+        self.mean_min = mean_min
+        self.mean_max = mean_max
+        self.is_int = is_int
+        self.min_val = min_val
+
+    def __call__(self, shape: torch.Size | None = None):
+        log_min = math.log(self.mean_min)
+        log_max = math.log(self.mean_max)
+        size = shape or (1,)
+        sigma = torch.exp((log_max - log_min) * torch.rand(size) + log_min)
+        mu = torch.exp((log_max - log_min) * torch.rand(size) + log_min)
+
+        loi = torch.distributions.Normal(mu, sigma)
+        round = (lambda x: torch.round(x).int()) if self.is_int else (lambda x: x)
+        samples = round(loi.icdf((torch.rand(size) - 1) * (1 - loi.cdf(torch.zeros(size))) + 1) + self.min_val)
+        samples = torch.where(samples > self.min_val, samples, self.min_val * torch.ones_like(samples))
+        samples = samples if shape is not None else samples.item()
+        return samples
+
+
+class UniformSampler:
+    """Samples noise from a laplace distribution upon calling"""
+
+    def __init__(self, low: float, high: float):
+        self.low = low
+        self.high = high
+
+    def __call__(self, shape: torch.Size | None = None) -> torch.Tensor:
+        if shape is None:
+            ret = torch.rand((1,)).item()
+        else:
+            ret = torch.rand(shape)
+        return ret * (self.high - self.low) + self.low
+
+
+### Categorical ###
+def num2cat(numerical_tensor: torch.Tensor, max_categories: int, ordered_p: float) -> torch.Tensor:
+    """
+    Convert continuous numeric data into categorical data with optional randomization.
+
+    This function transforms a continuous numeric tensor into a categorical tensor
+    by creating class boundaries. It can also randomize the ordering of categories
+    based on the provided probability parameter.
+
+    Args:
+        numerical_tensor: Input tensor with continuous numeric values, shape: (seq_len,)
+        max_categories: Maximum number of categories to create
+        ordered_p: Probability to keep categories ordered (vs randomized) Higher values mean categories are more likely
+                  to remain ordered
+
+    Returns:
+        Categorical tensor as float values
+    """
+
+    if numerical_tensor.ndim != 1:
+        raise PriorGenerationError("Input tensor must be 1-dimensional")
+
+    categorical = torch.empty_like(numerical_tensor)
+    num_classes = torch.randint(2, max(3, max_categories + 1), (1,), device=numerical_tensor.device).item()
+
+    if torch.rand(1) > 0.5:
+        numerical_tensor = -numerical_tensor
+
+    sorted_num, categorical = torch.unique(numerical_tensor, return_inverse=True)
+    if len(sorted_num) >= num_classes + 1:
+        # Randomly select boundary values
+        boundary_indices = torch.randperm(len(sorted_num) - 2, device=numerical_tensor.device)[: num_classes - 1]
+        cls_bdry: torch.Tensor = sorted_num[1:-1][boundary_indices]
+
+        # Convert to categorical by counting how many boundaries each value exceeds
+        reshaped_num = numerical_tensor.reshape((-1, 1))  # shape: (seq_len, 1)
+        reshaped_bdry = cls_bdry.reshape(1, -1)  # shape: (1, num_classes - 1)
+        categorical = (reshaped_num > reshaped_bdry).sum(dim=1)  # shape: (seq_len,)
+
+    if torch.rand(1) > ordered_p:
+        classes = torch.arange(0, num_classes, device=categorical.device)
+        random_classes = torch.randperm(num_classes, device=categorical.device).type(categorical.type())
+        categorical = ((categorical.unsqueeze(-1) == classes) * random_classes).sum(-1)
+
+    return categorical.float()
+
+
+###### Controlling overlap and heterogeneity
+
+
+def degree_heterogeneity(
+    y0: torch.Tensor,
+    y1: torch.Tensor,
+    deg_hetero: float,
+) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
+    """
+    For deg_hetero = 1, y1 and y0 remain unchanged. For deg_hetero = 0, y1 - y0 is the same for all individuals.
+    For 0 < deg_hetero < 1, y1 and y0 are changed such that the CATE is a linear interpolation between the
+    original CATE and the constant ATE. The code is from
+    https://github.com/bradyneal/realcause/blob/master/models/base.py
+    """
+    if deg_hetero < 0 or deg_hetero > 1:
+        raise PriorGenerationError(f"deg_hetero not in [0, 1], got {deg_hetero}")
+    y1_mean = y1.mean()
+    y0_mean = y0.mean()
+    ate = y1_mean - y0_mean
+
+    alpha = torch.rand(y1.shape, device=y1.device)
+
+    y1_scale = alpha + (1 - alpha) * deg_hetero
+    y1_shift = (1 - deg_hetero) * (y0 + ate) * (1 - alpha)
+
+    y0_scale = (1 - alpha) + alpha * deg_hetero
+    y0_shift = (1 - deg_hetero) * (y1 - ate) * alpha
+
+    return (y0_scale, y0_shift), (y1_scale, y1_shift)
+
+
+def scale_causal_effect(
+    y0: torch.Tensor,
+    y1: torch.Tensor,
+    causal_effect_scale: float,
+) -> torch.Tensor:
+    """
+    Scales the causal effect E[y1 - y0] by the given `causal_effect_scale`. The code is from
+    https://github.com/bradyneal/realcause/blob/master/models/base.py
+    """
+    if causal_effect_scale <= 0:
+        raise PriorGenerationError(f"causal_effect_scale must be positive, got {causal_effect_scale}")
+    ate = (y1 - y0).mean()
+    return causal_effect_scale / ate

--- a/src/causalpfn/training/trainer.py
+++ b/src/causalpfn/training/trainer.py
@@ -1,0 +1,283 @@
+import math
+from contextlib import nullcontext
+from typing import Any, Callable, Dict
+
+import torch
+import wandb
+from tqdm import tqdm
+
+from causalpfn.models import InContextModel
+
+from .priors.meta_dataset import MetaDataset
+
+
+def distributed_mean(value: float, device: str, using_dist: bool, world_size: int) -> float:
+    if not using_dist:
+        return value
+    reduced = torch.tensor(value, dtype=torch.float64, device=device)
+    torch.distributed.all_reduce(reduced, op=torch.distributed.ReduceOp.SUM)
+    return (reduced / world_size).item()
+
+
+def calculate_loss(
+    model: InContextModel,
+    device: str,
+    batch: dict,
+    min_train_data_split: float,
+    max_train_data_split: float,
+    # Ignore a table when either treatment arm has fewer than this fraction of context samples.
+    overlap_threshold: float = 0.05,
+) -> torch.Tensor:
+    """
+    This function uses an in-context model to compute the loss for training the causal (foundation) model.
+    `model` itself is a PFN-style model that takes in `t_train` `X_train, y_train` and an `X_query` and `t_query`
+    and then produces expected potential outcome predictions.
+
+    *Note*:
+        The final loss averages the valid table losses in a batch. Tables with non-finite losses or insufficient treatment
+        overlap are ignored.
+
+    Args:
+        model: The in-context model to use for training.
+        device: The device to use for training.
+        batch: The batch of data to use for training.
+        min_train_data_split: The minimum fraction of training data to use for context.
+        max_train_data_split: The maximum fraction of training data to use for context.
+        overlap_threshold: The threshold for the overlap condition.
+    Returns:
+        avg_total_loss: The average total loss for the batch.
+    """
+    # shuffle the covariate columns to induce column permutation invariance
+    X = batch["X"].to(device, non_blocking=True)  # shape: (batch_size, num_rows, num_features)
+    idx = torch.randperm(batch["X"].shape[-1], device=device)  # create idx on GPU
+    X = X[:, :, idx]  # shape: (batch_size, num_rows, num_features)
+    split_pos = int(
+        X.shape[1] * (torch.rand(()) * (max_train_data_split - min_train_data_split) + min_train_data_split)
+    )
+    t = batch["t"].to(device, non_blocking=True)  # shape: (batch_size, num_rows)
+    y = batch["y"].to(device, non_blocking=True)  # shape: (batch_size, num_rows)
+    E_y0, E_y1 = batch["E_y0"].to(device, non_blocking=True), batch["E_y1"].to(
+        device, non_blocking=True
+    )  # shape: (batch_size, num_rows)
+    # compute the cepo loss
+    cepo_losses = model(
+        X_context=X[:, :split_pos],
+        t_context=t[:, :split_pos],
+        y_context=y[:, :split_pos],
+        X_query=X[:, split_pos:],
+        E_y0_query=E_y0[:, split_pos:],
+        E_y1_query=E_y1[:, split_pos:],
+    )
+    # ignore the the tables where the treatment or control group has less than threshold samples
+    # This basically ignores the tables where the overlap condition is not satisfied
+    t_context = t[:, :split_pos]
+    treated_counts = (t_context == 1).long().sum(dim=1)
+    control_counts = (t_context == 0).long().sum(dim=1)
+    # some tables might be ignored in the loss calculation here
+    valid_mask = torch.ones(batch["X"].shape[0], dtype=torch.bool, device=device)
+    valid_mask &= treated_counts >= overlap_threshold * split_pos
+    valid_mask &= control_counts >= overlap_threshold * split_pos
+    valid_mask &= torch.isfinite(cepo_losses)
+    valid_losses = cepo_losses[valid_mask]
+    if valid_losses.numel() > 0:
+        return valid_losses.mean()
+
+    # A standalone zero would bypass DDP's gradient hooks and can deadlock when
+    # another rank has valid tables. Attach a finite zero to every trainable
+    # parameter so all ranks participate with zero gradients for this batch.
+    zero_loss = cepo_losses.new_zeros(())
+    for parameter in model.parameters():
+        if parameter.requires_grad:
+            zero_loss = zero_loss + parameter.reshape(-1)[0] * 0.0
+    return zero_loss
+
+
+def train(
+    model: InContextModel,
+    max_epochs: int,
+    num_agg: int,
+    num_model_updates: int,
+    optimizer_partial: Callable[[Any], torch.optim.Optimizer],
+    train_meta_dataset: MetaDataset,
+    callbacks: list,
+    lr_scheduler_partial: Callable[[torch.optim.Optimizer], Any] | None,
+    compile: bool,
+    num_workers: int,
+    prefetch_factor: int,
+    checkpoint: Dict[str, Any] | None,
+    wandb_enabled: bool,
+    batch_size: int,
+    grad_clip: float | None,
+    device: str,
+    min_train_data_split: float,
+    max_train_data_split: float,
+    overlap_threshold: float,
+    rank: int,
+    using_dist: bool,
+    world_size: int,
+):
+    """
+    Takes a model designed for prior-fitting (`model`) and then trains CATE on a given set of datasets.
+
+    Evaluation is handled through callbacks in ``causalpfn.training.callbacks``.
+    """
+
+    barrier_kwargs = {"device_ids": [torch.device(device).index]} if device.startswith("cuda") else {}
+
+    model.to(device)
+    model.train()
+
+    if compile:
+        # Dynamic shapes are required because the context/query split changes each batch.
+        model = torch.compile(model, dynamic=True)
+
+    if using_dist:
+        ddp_kwargs = {}
+        if device.startswith("cuda"):
+            local_device_index = torch.device(device).index
+            ddp_kwargs = {"device_ids": [local_device_index], "output_device": local_device_index}
+        model = torch.nn.parallel.DistributedDataParallel(model, **ddp_kwargs)
+        optimizer = optimizer_partial(model.module.get_param_groups())
+    else:
+        optimizer = optimizer_partial(model.get_param_groups())
+
+    if checkpoint:  # load optimizer state if resume = True
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        start_epoch = checkpoint["epoch"] + 1
+    else:
+        start_epoch = 0
+
+    lr_scheduler: torch.optim.lr_scheduler.LRScheduler = (
+        lr_scheduler_partial(optimizer) if lr_scheduler_partial is not None else None
+    )
+    if checkpoint and lr_scheduler is not None and checkpoint.get("lr_scheduler_state_dict") is not None:
+        lr_scheduler.load_state_dict(checkpoint["lr_scheduler_state_dict"])
+    loader_kwargs = {
+        "batch_size": batch_size,
+        "num_workers": num_workers,
+        "pin_memory": device.startswith("cuda"),
+        "persistent_workers": num_workers > 0,
+    }
+    if num_workers > 0:
+        loader_kwargs["prefetch_factor"] = prefetch_factor
+    train_loader = torch.utils.data.DataLoader(train_meta_dataset, **loader_kwargs)
+    train_loader_iterator = iter(train_loader)
+
+    # create three progress bars
+    pbar_train = tqdm(
+        range(max_epochs * num_model_updates * num_agg * world_size), desc="Train Batches", disable=(rank != 0)
+    )
+
+    print(f"Effective batch size is: {num_agg * batch_size * world_size}")
+
+    for epoch in range(max_epochs):
+        if epoch < start_epoch:
+            pbar_train.update(num_model_updates * num_agg * world_size)
+            continue
+
+        model.train()
+        if hasattr(optimizer, "train"):  # for schedulefree
+            optimizer.train()
+
+        # run the model for num_agg * num_model_updates iterations
+        total_loss = 0.0
+        for batch_counter in range(num_agg * num_model_updates):
+            # accumate the loss gradients over num_agg batches for larger effective batch size
+            train_batch = next(train_loader_iterator)
+            last_micro_batch = ((batch_counter + 1) % num_agg) == 0
+            sync_context = model.no_sync() if using_dist and not last_micro_batch else nullcontext()
+            with sync_context:
+                with torch.autocast(
+                    device_type="cuda" if device.startswith("cuda") else "cpu",
+                    dtype=torch.bfloat16,
+                ):
+                    loss = calculate_loss(
+                        model,
+                        device,
+                        batch=train_batch,
+                        min_train_data_split=min_train_data_split,
+                        max_train_data_split=max_train_data_split,
+                        overlap_threshold=overlap_threshold,
+                    )
+                    loss = loss / num_agg
+                    total_loss += loss.item()
+                    loss.backward()
+
+            if last_micro_batch:
+                # short-circuit if the gradients are messed up
+                grad_norm = torch.nn.utils.clip_grad_norm_(
+                    model.parameters(), max_norm=grad_clip or float("inf")
+                ).item()
+                # A generated task can occasionally be numerically degenerate; discard its update on every rank.
+                skip_local = (grad_norm == 0) or math.isinf(grad_norm) or math.isnan(grad_norm)
+                skip_flag = torch.tensor(skip_local, device=device, dtype=torch.uint8)
+                if using_dist:
+                    torch.distributed.all_reduce(skip_flag, op=torch.distributed.ReduceOp.MAX)
+
+                pbar_train.update(num_agg * world_size)
+
+                if skip_flag.item():
+                    optimizer.zero_grad(set_to_none=True)  # discard the bad step
+                    print("[Warning] non-finite, NaN, or empty gradients – skipping update.")
+                    continue
+
+                if wandb_enabled and rank == 0:
+                    with torch.no_grad():
+                        weight_norm = torch.linalg.vector_norm(
+                            torch.stack([p.norm() for p in model.parameters()])
+                        ).item()
+                    wandb.log(
+                        {
+                            f"weights/grad_norm": grad_norm,
+                            f"weights/weight_norm": weight_norm,
+                            f"weights/avg_lr": sum(
+                                [optimizer.param_groups[i]["lr"] for i in range(len(optimizer.param_groups))]
+                            )
+                            / len(optimizer.param_groups),
+                        },
+                    )
+
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+                if lr_scheduler is not None:
+                    lr_scheduler.step()
+
+        # update the loss reports
+        total_loss /= num_model_updates
+        total_loss = distributed_mean(total_loss, device, using_dist, world_size)
+        loss_report = {"train/loss": total_loss}
+
+        # log the loss values
+        pbar_train.set_postfix(loss_report)
+        if wandb_enabled:
+            wandb.log(loss_report)
+
+        if using_dist:
+            torch.distributed.barrier(**barrier_kwargs)
+
+        # make the optimizer eval mode
+        if hasattr(optimizer, "eval"):
+            optimizer.eval()
+
+        # run the __call__ method of each callback
+        for i, callback in enumerate(callbacks):
+            pbar_train.set_description(f"Total Epochs (Callback [{i+1}/{len(callbacks)}])")
+            callback(
+                callback_idx=i,
+                model=model if not isinstance(model, torch.nn.parallel.DistributedDataParallel) else model.module,
+                optimizer=optimizer,
+                epoch=epoch,
+                train_loss=total_loss,
+                device=device,
+                rank=rank,
+                wandb_enabled=wandb_enabled,
+                lr_scheduler=lr_scheduler,
+            )
+            pbar_train.set_description("Total Epochs (Training ...)")
+
+        # bring back the optimizer to train mode
+        if hasattr(optimizer, "train"):
+            optimizer.train()
+
+        if using_dist:
+            torch.distributed.barrier(**barrier_kwargs)

--- a/tests/test_training_bridge.py
+++ b/tests/test_training_bridge.py
@@ -1,0 +1,60 @@
+import pytest
+import torch
+
+from causalpfn.models import InContextModel, TabDPTLongContextModel
+from causalpfn.models.utils import pad_x
+
+
+def test_pad_x_uses_zero_padding_and_preserves_dtype():
+    values = torch.ones(2, 2, dtype=torch.float64)
+    padded = pad_x(values, num_features=5)
+    assert padded.shape == (2, 5)
+    assert padded.dtype == values.dtype
+    assert torch.equal(padded[:, :2], values)
+    assert torch.equal(padded[:, 2:], torch.zeros(2, 3, dtype=values.dtype))
+
+
+def test_pad_x_rejects_smaller_target():
+    with pytest.raises(ValueError, match="smaller size"):
+        pad_x(torch.ones(2, 3), num_features=2)
+
+
+def test_in_context_model_exposes_optimizer_groups():
+    inner = TabDPTLongContextModel(
+        dropout=0.0,
+        n_out=2,
+        nhead=1,
+        nhid=8,
+        ninp=4,
+        nlayers=1,
+        num_features=4,
+        nbins=8,
+    )
+    config = {"model": {"nbins": 8, "max_num_features": 4}}
+    model = InContextModel(inner, config)
+    groups = model.get_param_groups()
+    assert len(groups) == 2
+    assert groups[1]["weight_decay"] == 0.0
+
+
+def test_in_context_model_prepares_input_without_instance_closure():
+    inner = TabDPTLongContextModel(
+        dropout=0.0,
+        n_out=2,
+        nhead=1,
+        nhid=8,
+        ninp=4,
+        nlayers=1,
+        num_features=4,
+        nbins=8,
+    )
+    model = InContextModel(inner, {"model": {"nbins": 8, "max_num_features": 4}})
+    x = torch.ones(2, 3)
+    y = torch.arange(2)
+
+    padded_x, returned_y = model.prepare_input(x, y)
+
+    assert "prepare_input" not in model.__dict__
+    assert padded_x.shape == (2, 4)
+    assert torch.equal(padded_x[:, -1], torch.zeros(2))
+    assert returned_y is y

--- a/tests/test_training_callbacks.py
+++ b/tests/test_training_callbacks.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from causalpfn.training.callbacks import EvalCATE
+
+
+class OneEvaluationDataset:
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        cate = SimpleNamespace(
+            X_train=np.zeros((4, 2)),
+            t_train=np.array([0, 1, 0, 1]),
+            y_train=np.zeros(4),
+            X_test=np.zeros((2, 2)),
+            true_cate=np.zeros(2),
+        )
+        return cate, SimpleNamespace()
+
+
+class FakeEstimator:
+    def fit(self, **kwargs):
+        return self
+
+    def estimate_cate(self, X):
+        return np.zeros(len(X))
+
+
+def test_nonzero_rank_does_not_evaluate_or_change_model_mode():
+    calls = []
+    callback = EvalCATE(
+        eval_datasets={"tiny": OneEvaluationDataset()},
+        cate_estimator_partial=lambda **kwargs: calls.append(kwargs),
+        callback_name="eval",
+    )
+    model = torch.nn.Linear(2, 1)
+    model.train()
+
+    callback(0, model, None, 0, 0.0, "cuda:1", 1, False)
+
+    assert calls == []
+    assert callback.pbar is None
+    assert model.training
+
+
+def test_rank_zero_evaluation_uses_resolved_runtime_device():
+    calls = []
+
+    def make_estimator(**kwargs):
+        calls.append(kwargs)
+        return FakeEstimator()
+
+    callback = EvalCATE(
+        eval_datasets={"tiny": OneEvaluationDataset()},
+        cate_estimator_partial=make_estimator,
+        callback_name="eval",
+    )
+    model = torch.nn.Linear(2, 1)
+
+    callback(0, model, None, 0, 0.0, "cuda:3", 0, False)
+    callback.pbar.close()
+
+    assert calls[0]["device"] == "cuda:3"
+    assert calls[0]["icl_model"] is model
+    assert model.training

--- a/tests/test_training_checkpoint.py
+++ b/tests/test_training_checkpoint.py
@@ -1,0 +1,94 @@
+import torch
+
+from causalpfn.training.callbacks import Checkpoint
+
+
+class CheckpointModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(2.0))
+        self.model_config = {"model_type": "test", "sigma": 0.01}
+
+
+def test_checkpoint_contains_resumable_state(tmp_path):
+    model = CheckpointModel()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5)
+    optimizer.step()
+    scheduler.step()
+    callback = Checkpoint(
+        checkpoint_root=str(tmp_path),
+        callback_name="checkpoint",
+        frequency=1,
+        checkpoint_dir_name="test-run",
+        top_k=1,
+    )
+
+    callback(
+        callback_idx=0,
+        model=model,
+        optimizer=optimizer,
+        epoch=0,
+        train_loss=0.5,
+        device="cpu",
+        rank=0,
+        wandb_enabled=False,
+        lr_scheduler=scheduler,
+    )
+
+    saved = torch.load(tmp_path / "test-run" / "latest.pt", weights_only=False, map_location="cpu")
+    assert saved["epoch"] == 0
+    assert saved["train_loss"] == 0.5
+    assert saved["model_config"] == model.model_config
+    assert "weight" in saved["model_state_dict"]
+    assert saved["optimizer_state_dict"]["param_groups"]
+    assert saved["lr_scheduler_state_dict"] == scheduler.state_dict()
+    assert saved["checkpoint_dir_name"] == "test-run"
+    assert saved["top_scores"] == [0.5]
+    assert saved["top_epochs"] == [0]
+
+
+def test_checkpoint_resume_preserves_custom_directory_and_bounded_top_k(tmp_path):
+    model = CheckpointModel()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    callback = Checkpoint(
+        checkpoint_root=str(tmp_path),
+        callback_name="checkpoint",
+        frequency=1,
+        checkpoint_dir_name="custom-directory",
+        top_k=1,
+    )
+    callback(0, model, optimizer, 0, 0.5, "cpu", 0, False)
+    first = torch.load(tmp_path / "custom-directory" / "latest.pt", weights_only=False)
+
+    resumed = Checkpoint(
+        checkpoint_root=str(tmp_path),
+        callback_name="checkpoint",
+        frequency=1,
+        checkpoint_dir_name=None,
+        top_k=1,
+    )
+    resumed.load_state(first)
+    resumed(0, model, optimizer, 1, 0.4, "cpu", 0, False)
+
+    checkpoint_dir = tmp_path / "custom-directory"
+    assert resumed.checkpoint_dir_name == "custom-directory"
+    assert [path.name for path in checkpoint_dir.glob("epoch_*.pt")] == ["epoch_0001.pt"]
+    latest = torch.load(checkpoint_dir / "latest.pt", weights_only=False)
+    assert latest["top_scores"] == [0.4]
+    assert latest["top_epochs"] == [1]
+
+
+def test_checkpoint_accepts_legacy_state(tmp_path):
+    callback = Checkpoint(
+        checkpoint_root=str(tmp_path),
+        callback_name="checkpoint",
+        frequency=1,
+        checkpoint_dir_name=None,
+        top_k=2,
+    )
+    callback.load_state({"run_name": "legacy-run"})
+
+    assert callback.checkpoint_dir_name == "legacy-run"
+    assert callback.top_scores == [float("inf"), float("inf")]
+    assert callback.top_epochs == [-1, -1]

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+
+EXPERIMENTS = [
+    "simple_configuration",
+    "synthetic_backdoor",
+    "ablation_polynomial_backdoor",
+    "ablation_sinusoidal_backdoor",
+]
+PINNED_REVISION = "83aad07da1cb077cfda4236878a1b07dc9f72a54"
+
+
+@pytest.mark.parametrize("experiment", EXPERIMENTS)
+def test_retained_experiments_compose_with_warm_start_and_generate_a_prior(experiment):
+    config_dir = Path(__file__).resolve().parents[1] / "conf"
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        config = compose(
+            config_name="train",
+            overrides=[f"+experiment={experiment}", "train_meta_dataset.n_samples=32"],
+        )
+
+    assert config.model.path is None
+    assert config.model.revision == PINNED_REVISION
+    assert config.model.obj._target_.endswith("load_pretrained_in_context_model")
+
+    prior = instantiate(config.train_meta_dataset)
+    sample = next(iter(prior))
+    assert sample["X"].shape == (32, 99)
+    assert set(sample) == {"X", "t", "y", "y0", "y1", "E_y0", "E_y1", "propensities"}
+    assert all(torch.isfinite(value).all() for value in sample.values())
+
+
+def test_random_initialization_remains_an_explicit_override():
+    config_dir = Path(__file__).resolve().parents[1] / "conf"
+    with initialize_config_dir(version_base=None, config_dir=str(config_dir)):
+        config = compose(
+            config_name="train",
+            overrides=["+experiment=synthetic_backdoor", "model=tabdpt_long_context"],
+        )
+
+    assert config.model.obj._target_.endswith("InContextModel")

--- a/tests/test_training_loading.py
+++ b/tests/test_training_loading.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from causalpfn.models import TabDPTLongContextModel, loading
+
+
+def make_predictive_checkpoint(path: Path) -> None:
+    model = TabDPTLongContextModel(
+        dropout=0.0,
+        n_out=4,
+        nhead=1,
+        nhid=8,
+        ninp=4,
+        nlayers=1,
+        num_features=4,
+        nbins=8,
+    )
+    config = OmegaConf.create(
+        {
+            "training": {"dropout": 0.0},
+            "model": {
+                "max_num_classes": 4,
+                "nhead": 1,
+                "emsize": 4,
+                "nhid_factor": 2,
+                "nlayers": 1,
+                "max_num_features": 4,
+                "nbins": 8,
+            },
+        }
+    )
+    torch.save({"cfg": config, "model": model.state_dict()}, path)
+
+
+def test_local_checkpoint_takes_precedence_and_is_loaded_once(tmp_path, monkeypatch):
+    checkpoint_path = tmp_path / "warm.ckpt"
+    make_predictive_checkpoint(checkpoint_path)
+    original_load = torch.load
+    load_count = 0
+
+    def counted_load(*args, **kwargs):
+        nonlocal load_count
+        load_count += 1
+        return original_load(*args, **kwargs)
+
+    monkeypatch.setattr(loading.torch, "load", counted_load)
+    monkeypatch.setattr(loading, "hf_hub_download", lambda **kwargs: pytest.fail("local path must take precedence"))
+
+    model = loading.load_pretrained_in_context_model(
+        ckpt_path=checkpoint_path,
+        repo_id="unused/repo",
+        filename="unused.ckpt",
+        revision="unused-revision",
+        sigma=0.01,
+    )
+
+    assert load_count == 1
+    assert model.model_config["model"]["nbins"] == 8
+    assert model.sigma == 0.01
+
+
+def test_hugging_face_resolution_uses_pinned_revision(tmp_path, monkeypatch):
+    checkpoint_path = tmp_path / "warm.ckpt"
+    checkpoint_path.touch()
+    calls = []
+    monkeypatch.setattr(loading, "hf_hub_download", lambda **kwargs: calls.append(kwargs) or str(checkpoint_path))
+
+    resolved = loading.resolve_pretrained_checkpoint(
+        ckpt_path=None,
+        repo_id="vdblm/causalpfn",
+        filename="tabdpt_long_context.ckpt",
+        revision="immutable-commit",
+    )
+
+    assert resolved == str(checkpoint_path)
+    assert calls == [
+        {
+            "repo_id": "vdblm/causalpfn",
+            "filename": "tabdpt_long_context.ckpt",
+            "revision": "immutable-commit",
+        }
+    ]
+
+
+def test_checkpoint_resolution_reports_missing_artifacts(tmp_path):
+    with pytest.raises(FileNotFoundError, match="warm-start checkpoint not found"):
+        loading.resolve_pretrained_checkpoint(tmp_path / "missing.ckpt", None, None, None)
+
+    with pytest.raises(ValueError, match="pinned revision"):
+        loading.resolve_pretrained_checkpoint(None, "vdblm/causalpfn", "tabdpt_long_context.ckpt", None)

--- a/tests/test_training_loss.py
+++ b/tests/test_training_loss.py
@@ -1,0 +1,142 @@
+import torch
+from torch.utils.data import IterableDataset
+
+from causalpfn.training.trainer import calculate_loss, distributed_mean, train
+
+
+class ScalarLossModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(1.0))
+        self.model_config = {"model_type": "test"}
+
+    def get_param_groups(self):
+        return self.parameters()
+
+    def forward(self, X_context, **kwargs):
+        return self.weight.square().expand(X_context.shape[0])
+
+
+class NonFiniteLossModel(ScalarLossModel):
+    def forward(self, X_context, **kwargs):
+        return (self.weight * torch.full((), float("nan"))).expand(X_context.shape[0])
+
+
+class TinyMetaDataset(IterableDataset):
+    def __iter__(self):
+        while True:
+            yield {
+                "X": torch.randn(12, 4),
+                "t": torch.tensor([0.0, 1.0] * 6),
+                "y": torch.randn(12),
+                "E_y0": torch.randn(12),
+                "E_y1": torch.randn(12),
+            }
+
+
+def make_batch():
+    return {
+        "X": torch.randn(2, 12, 4),
+        "t": torch.tensor([[0.0, 1.0] * 6, [1.0, 0.0] * 6]),
+        "y": torch.randn(2, 12),
+        "E_y0": torch.randn(2, 12),
+        "E_y1": torch.randn(2, 12),
+    }
+
+
+def test_calculate_loss_is_differentiable():
+    model = ScalarLossModel()
+    loss = calculate_loss(model, "cpu", make_batch(), 0.5, 0.5, overlap_threshold=0.1)
+    loss.backward()
+    assert loss.item() == 1.0
+    assert model.weight.grad.item() == 2.0
+
+
+def test_calculate_loss_keeps_graph_when_every_table_is_invalid():
+    model = NonFiniteLossModel()
+    loss = calculate_loss(model, "cpu", make_batch(), 0.5, 0.5, overlap_threshold=0.1)
+    loss.backward()
+    assert loss.item() == 0.0
+    assert model.weight.grad is not None
+    assert model.weight.grad.item() == 0.0
+
+
+def test_one_cpu_optimizer_update_with_no_workers():
+    model = ScalarLossModel()
+    initial_weight = model.weight.detach().clone()
+
+    train(
+        model=model,
+        max_epochs=1,
+        num_agg=1,
+        num_model_updates=1,
+        optimizer_partial=lambda parameters: torch.optim.SGD(parameters, lr=0.1),
+        train_meta_dataset=TinyMetaDataset(),
+        callbacks=[],
+        lr_scheduler_partial=None,
+        compile=False,
+        num_workers=0,
+        prefetch_factor=2,
+        checkpoint=None,
+        wandb_enabled=False,
+        batch_size=2,
+        grad_clip=1.0,
+        device="cpu",
+        min_train_data_split=0.5,
+        max_train_data_split=0.5,
+        overlap_threshold=0.1,
+        rank=0,
+        using_dist=False,
+        world_size=1,
+    )
+
+    assert not torch.equal(model.weight.detach(), initial_weight)
+
+
+def test_distributed_mean_uses_all_ranks(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda tensor, op: tensor.mul_(2))
+    assert distributed_mean(3.0, "cpu", using_dist=True, world_size=2) == 3.0
+
+
+def test_training_restores_and_continues_scheduler_state():
+    source_model = ScalarLossModel()
+    source_optimizer = torch.optim.SGD(source_model.parameters(), lr=0.1)
+    source_scheduler = torch.optim.lr_scheduler.StepLR(source_optimizer, step_size=1, gamma=0.5)
+    source_optimizer.step()
+    source_scheduler.step()
+    checkpoint = {
+        "optimizer_state_dict": source_optimizer.state_dict(),
+        "lr_scheduler_state_dict": source_scheduler.state_dict(),
+        "epoch": 0,
+    }
+    observed = {}
+
+    def callback(**kwargs):
+        observed["scheduler"] = kwargs["lr_scheduler"].state_dict()
+
+    train(
+        model=ScalarLossModel(),
+        max_epochs=2,
+        num_agg=1,
+        num_model_updates=1,
+        optimizer_partial=lambda parameters: torch.optim.SGD(parameters, lr=0.1),
+        train_meta_dataset=TinyMetaDataset(),
+        callbacks=[callback],
+        lr_scheduler_partial=lambda optimizer: torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5),
+        compile=False,
+        num_workers=0,
+        prefetch_factor=2,
+        checkpoint=checkpoint,
+        wandb_enabled=False,
+        batch_size=2,
+        grad_clip=1.0,
+        device="cpu",
+        min_train_data_split=0.5,
+        max_train_data_split=0.5,
+        overlap_threshold=0.1,
+        rank=0,
+        using_dist=False,
+        world_size=1,
+    )
+
+    assert observed["scheduler"]["last_epoch"] == source_scheduler.last_epoch + 1

--- a/tests/test_training_prior.py
+++ b/tests/test_training_prior.py
@@ -1,0 +1,104 @@
+import numpy as np
+import torch
+
+from benchmarks.polynomial import PolynomialDataset
+from causalpfn.training import priors
+from causalpfn.training.priors import BackdoorDGPMetaDataset, table_generators
+from causalpfn.training.priors.table_generators import SyntheticTableGenerator, TableGenerator
+
+
+class GaussianTableGenerator(TableGenerator):
+    def __init__(self):
+        super().__init__(name="gaussian", device="cpu")
+
+    def _sample_table(self, n_samples: int, n_columns: int) -> torch.Tensor:
+        return torch.randn(n_samples, n_columns)
+
+
+class RandomizedTreatmentGenerator(TableGenerator):
+    def __init__(self):
+        super().__init__(name="randomized-treatment", device="cpu")
+
+    def _sample_conditional_table(self, input: torch.Tensor, n_columns: int) -> torch.Tensor:
+        return torch.zeros(input.shape[0], n_columns)
+
+
+def test_synthetic_backdoor_prior_produces_padded_causal_batch():
+    torch.manual_seed(7)
+    prior = BackdoorDGPMetaDataset(
+        X_y0_E_y0_y1_E_y1_generator=GaussianTableGenerator(),
+        T_given_X_generator=RandomizedTreatmentGenerator(),
+        max_n_covariates=4,
+        layer_norm_covariates_prob=0.5,
+        n_samples=128,
+        overlap_dist=lambda: 1.0,
+        treatment_standardize_p=0.5,
+        degree_heterogeneity_dist=lambda: 1.0,
+        device="cpu",
+        ate_scale_dist=None,
+        name="test-prior",
+        post_padding_n_cols=8,
+    )
+
+    sample = next(iter(prior))
+
+    assert sample["X"].shape == (128, 8)
+    assert set(sample) == {"X", "t", "y", "y0", "y1", "E_y0", "E_y1", "propensities"}
+    assert all(torch.isfinite(value).all() for value in sample.values())
+    assert set(sample["t"].unique().tolist()) == {0.0, 1.0}
+
+
+def test_removed_prior_types_are_not_exported():
+    assert set(priors.__all__) == {
+        "BackdoorDGPMetaDataset",
+        "DeepTruncNormLogScaledSampler",
+        "MetaDataset",
+        "PriorGenerationError",
+        "UniformSampler",
+    }
+    assert set(table_generators.__all__) == {"SyntheticTableGenerator", "TableGenerator"}
+
+
+def test_synthetic_treatment_generator_selects_linear_with_ten_percent_probability(monkeypatch):
+    generator = SyntheticTableGenerator(
+        device="cpu",
+        n_layer_dist=lambda: 1,
+        n_hidden_dist=lambda: 2,
+        dense_prob_dist=lambda: 1.0,
+        init_std_dist=lambda: 1.0,
+        noise_std_dist=lambda: 0.0,
+        n_block_max_dist=None,
+        categorical_columns_prob=0.0,
+        categorical_columns_ordered_prob=0.0,
+        independent_prob=0.0,
+        linear_probability=0.1,
+    )
+    draws = iter([torch.tensor([0.5]), torch.tensor([0.05]), torch.tensor([0.5]), torch.tensor([0.5])])
+    monkeypatch.setattr(torch, "rand", lambda *args, **kwargs: next(draws))
+    monkeypatch.setattr(generator, "_sample_linear_conditional_table", lambda input, n_columns: input.new_ones(3, 1))
+    monkeypatch.setattr(
+        generator,
+        "_sample_nonlinear_conditional_table",
+        lambda input, n_columns: input.new_zeros(3, 1),
+    )
+
+    inputs = torch.randn(3, 2)
+    assert torch.equal(generator.sample_conditional_table(inputs, 1), torch.ones(3, 1))
+    assert torch.equal(generator.sample_conditional_table(inputs, 1), torch.zeros(3, 1))
+
+
+def test_generalized_linear_dataset_accepts_zero_seed():
+    dataset = PolynomialDataset(n_tables=1, test_ratio=0.2, n_samples=32)
+    first = dataset.get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes(seed=0)
+    second = dataset.get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes(seed=0)
+    assert all(np.array_equal(left, right) for left, right in zip(first, second))
+
+
+def test_polynomial_defaults_and_covariate_standardization():
+    dataset = PolynomialDataset(n_tables=25, n_samples=64)
+    covariates = dataset.get_X_T_propensities_Y0_Y1_E_Y0_E_Y1_outcomes(seed=3)[0]
+
+    assert len(dataset) == 25
+    assert dataset.test_ratio == 0.2
+    assert np.allclose(covariates.mean(axis=0), 0.0, atol=1e-7)
+    assert np.allclose(covariates.std(axis=0), 1.0, atol=1e-7)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,93 @@
+"""Hydra entry point for CausalPFN training."""
+
+from typing import Any
+
+import hydra
+import torch
+import wandb
+from hydra.utils import instantiate
+from omegaconf import DictConfig, OmegaConf
+
+from causalpfn.models import InContextModel
+from causalpfn.training.callbacks import Checkpoint
+from causalpfn.training.distributed import cleanup, init_dist, install_signal_handler, seed_everything
+from causalpfn.training.trainer import train
+
+if not OmegaConf.has_resolver("eval"):
+    OmegaConf.register_new_resolver("eval", eval)
+
+
+@hydra.main(version_base=None, config_path="conf", config_name="train")
+def main(conf: DictConfig) -> Any:
+    install_signal_handler()
+    using_dist, rank, device, world_size = init_dist(conf.default_device)
+    seed_everything(conf.seed, using_dist, rank)
+
+    checkpoint = None
+    resume = False
+    run_name = None
+    wandb_run_id = None
+    if conf.resume_training.enabled and conf.resume_training.checkpoint_path is not None:
+        checkpoint = torch.load(conf.resume_training.checkpoint_path, weights_only=False, map_location=device)
+        run_name = checkpoint["run_name"]
+        if "wandb" in run_name:
+            wandb_run_id = run_name.split("-")[-1]
+        resume = True
+
+    model: InContextModel
+    if resume:
+        model = InContextModel.load(
+            model_state=checkpoint["model_state_dict"],
+            model_config=checkpoint["model_config"],
+        )
+    else:
+        model = instantiate(conf.model.obj)
+    train_meta_dataset = instantiate(conf.train_meta_dataset)
+
+    if conf.wandb.enabled and rank == 0:
+        wandb_run_name = str(conf.wandb.run_name) if conf.wandb.run_name is not None else None
+        tags = [f"{key}:{value}" for key, value in conf.wandb.tags.items()] if "tags" in conf.wandb else []
+        tags.append(f"num_gpus:{world_size}")
+        wandb.init(
+            project=conf.wandb.project,
+            entity=conf.wandb.entity,
+            config=OmegaConf.to_container(conf, resolve=True),
+            name=None if resume and wandb_run_id is not None else wandb_run_name,
+            tags=tags,
+            settings=wandb.Settings(start_method="thread"),
+            id=wandb_run_id,
+            resume="must" if resume and wandb_run_id is not None else "never",
+        )
+
+    callbacks = [instantiate(callback) for callback in conf.get("callbacks", {}).values()]
+    for callback in callbacks:
+        if isinstance(callback, Checkpoint) and resume:
+            callback.load_state(checkpoint)
+
+    try:
+        train(
+            model=model,
+            optimizer_partial=instantiate(conf.optimizer),
+            train_meta_dataset=train_meta_dataset,
+            callbacks=callbacks,
+            lr_scheduler_partial=instantiate(conf.lr_scheduler) if conf.get("lr_scheduler") else None,
+            compile=conf.compile,
+            num_workers=conf.num_workers,
+            prefetch_factor=conf.prefetch_factor,
+            checkpoint=checkpoint,
+            wandb_enabled=conf.wandb.enabled and rank == 0,
+            device=device,
+            rank=rank,
+            using_dist=using_dist,
+            world_size=world_size,
+            **OmegaConf.to_container(conf.trainer, resolve=True),
+        )
+    finally:
+        if conf.wandb.enabled and rank == 0:
+            wandb.finish()
+        if using_dist:
+            cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/train_parallel.sh
+++ b/train_parallel.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+master_addr=localhost
+master_port=24105
+forwarded_args=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --port=*) master_port="${arg#*=}" ;;
+    *) forwarded_args+=("$arg") ;;
+  esac
+done
+
+if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+  echo "CUDA_VISIBLE_DEVICES must list the GPUs to use." >&2
+  exit 2
+fi
+
+IFS=',' read -r -a gpu_ids <<< "$CUDA_VISIBLE_DEVICES"
+num_gpus=${#gpu_ids[@]}
+cpu_count=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)
+omp_threads=$((cpu_count / num_gpus))
+if ((omp_threads < 1)); then
+  omp_threads=1
+fi
+if ((omp_threads > 64)); then
+  omp_threads=64
+fi
+
+OMP_NUM_THREADS=$omp_threads torchrun \
+  --nproc_per_node "$num_gpus" \
+  --rdzv_endpoint "$master_addr:$master_port" \
+  train.py "${forwarded_args[@]}"


### PR DESCRIPTION
## Summary

- Add the causal training recipe used for CausalPFN.
- Warm-start training by default from the predictive TabDPT checkpoint hosted on Hugging Face at a pinned revision.
- Add synthetic causal priors and the polynomial and sinusoidal ablations.
- Add Hydra configurations, checkpoint/resume support, CATE evaluation, and distributed training through `torchrun`.
- Add training documentation, dependency extras, a CUDA environment, and offline CPU CI.
- Keep random initialization available through an explicit model override.

## Validation

- 27 offline tests pass on Python 3.10 with CPU-only PyTorch 2.5.1.
- All Hydra experiments compose and generate finite prior samples.
- Isolated wheel build and training-package import checks pass.
- Full two-epoch distributed training passed on two A100 GPUs with:
  - 2,048 rows per table
  - batch size 32 per rank
  - eight-step gradient accumulation
  - 128 optimizer updates per epoch
  - effective batch size 512
- CATE evaluation, checkpointing, rank synchronization, and distributed resume all passed.
- Black, isort, compilation, and `git diff --check` pass for the publication diff.
